### PR TITLE
First pass at adding audio APIs

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,23 +21,28 @@ module.exports = {
       },                  
       {
         title: 'Firefly APIs',
-        description: 'Docs and references for Firefly API',
+        description: 'Docs and references for Firefly APIs',
         path: '/firefly-api/' 
       },
       {
         title: 'Photoshop APIs',
-        description: 'Docs and references for Photoshop API',
+        description: 'Docs and references for Photoshop APIs',
         path: '/photoshop/'
       },
       {
         title: 'Lightroom APIs',
-        description: 'Docs and references for Lightroom API',
+        description: 'Docs and references for Lightroom APIs',
         path: '/lightroom/'
       },
       {
         title: 'Content Tagging APIs',
         description: 'Docs and references for Content Tagging services',        
         path: 'https://experienceleague.adobe.com/docs/experience-platform/intelligent-services/content-commerce-ai/overview.html'
+      },
+      {
+        title: 'Pro Audio & Video APIs',
+        description: 'Docs and references for Adobe Pro Audio and Video APIs',
+        path: '/audio_video/'
       },
     ],
     subPages: [  
@@ -82,11 +87,11 @@ module.exports = {
       {
         title: 'Concepts',
         path: '/firefly-api/guides/concepts/model-3-overview.md/',
-        pages: [
+        pages: [          
           {
             title: 'Firefly Image 3 Model (preview)',
             path: '/firefly-api/guides/concepts/model-3-overview.md/'
-          },      
+          },       
           {
             title: 'Authentication',
             path: '/firefly-api/guides/concepts/authentication/'
@@ -370,6 +375,106 @@ module.exports = {
         ]
       },    
       // END PS API left nav
+      ///////////////////////////////////////////////
+      // Pro Audio and Video APIs left nav
+      /////////////////////////////////////////////// 
+      {
+        title: 'Overview',    
+        path: '/audio_video/',    
+        header: true,
+        pages: [
+          {
+            title: 'Overview',
+            path: '/audio_video/',
+          },
+        ]
+      },
+      {
+        title: 'Audio Services',
+        path: '/audio_video/audio/',
+        header: true,
+        pages: [
+          {
+            title: 'Getting Started',
+            path: '/audio_video/audio/',
+          },
+          {
+            title: 'Usage Notes',
+            path: '/audio_video/audio/usage-notes.md',
+          },
+          {
+            title: 'API Reference',
+            path: '/audio_video/audio/api/create_asset.md',
+            pages: [
+              {
+                title: 'Create an asset',
+                path: '/audio_video/audio/api/create_asset.md',
+              },
+              {
+                title: 'Show an asset',
+                path: '/audio_video/audio/api/show_asset.md',
+              },
+              {
+                title: 'Delete an asset',
+                path: '/audio_video/audio/api/delete_asset.md',
+              },
+              {
+                title: 'Create a speech enhancement',
+                path: '/audio_video/audio/api/create_enhancement.md',
+              },
+              {
+                title: 'Get a speech enhancement',
+                path: '/audio_video/audio/api/get_enhancement.md'
+              },                
+            ]
+          }
+        ]        
+      },
+      {
+        title: 'Video Services',
+        path: '/audio_video/video/',
+        header: true,
+        pages: [
+          {
+            title: 'Coming soon...',
+            path: '/audio_video/video/'
+          }                    
+        ]
+      }
+      // {
+      //   title: 'Getting Started with Audio Services',
+      //   path: '/audio_video/audio/get-started.md',
+      // },
+      // {
+      //   title: 'Audio Services Usage Notes',
+      //   path: '/audio_video/audio/usage-notes.md',
+      // },
+      // {
+      //   title: 'API Reference',
+      //   path: '/audio_video/audio/api/create_asset.md',
+      //   pages: [
+      //     {
+      //       title: 'Create an asset',
+      //       path: '/audio_video/audio/api/create_asset.md',
+      //     },
+      //     {
+      //       title: 'Show an asset',
+      //       path: '/audio_video/audio/api/show_asset.md',
+      //     },
+      //     {
+      //       title: 'Delete an asset',
+      //       path: '/audio_video/audio/api/delete_asset.md',
+      //     },
+      //     {
+      //       title: 'Create a speech enhancement',
+      //       path: '/audio_video/audio/api/create_enhancement.md',
+      //     },
+      //     {
+      //       title: 'Get a speech enhancement',
+      //       path: '/audio_video/audio/api/get_enhancement.md'
+      //     },
+      //   ]
+      // }
       /////////////////////////////////////////////////////
       // TODO: Revisit including a file but one that's flattened, these roll to the API overview root
       // menu
@@ -386,6 +491,6 @@ module.exports = {
       // },
       ///////////////////////////////////////////////////// 
     ]
-  },
+  },    
   plugins: [`@adobe/gatsby-theme-aio`]
 };

--- a/src/pages/audio_video/audio/api/create_asset.md
+++ b/src/pages/audio_video/audio/api/create_asset.md
@@ -1,0 +1,14 @@
+---
+title: Create Asset - Adobe Pro Audio and Video APIs
+description: Create Asset API Reference for the Adobe Pro Audio and Video APIs
+keywords:
+  - Adobe Firefly Services
+  - Create Asset
+  - API Reference
+  - Adobe Pro Audio and Video APIs
+  - Developer documentation
+  - API documentation
+layout: none
+---
+
+<RedoclyAPIBlock src="/firefly-services/docs/audio_create_asset.json" width="600px" disableSidebar />

--- a/src/pages/audio_video/audio/api/create_enhancement.md
+++ b/src/pages/audio_video/audio/api/create_enhancement.md
@@ -1,0 +1,14 @@
+---
+title: Create Speech Enhancement - Adobe Pro Audio and Video APIs
+description: Create Speech Enhancement API Reference for the Adobe Pro Audio and Video APIs
+keywords:
+  - Adobe Firefly Services
+  - Create Speech Enhancement
+  - API Reference
+  - Adobe Pro Audio and Video APIs
+  - Developer documentation
+  - API documentation  
+layout: none
+---
+
+<RedoclyAPIBlock src="/firefly-services/docs/audio_create_enhancement.json" width="600px" disableSidebar />

--- a/src/pages/audio_video/audio/api/delete_asset.md
+++ b/src/pages/audio_video/audio/api/delete_asset.md
@@ -1,0 +1,14 @@
+---
+title: Delete Asset - Adobe Pro Audio and Video APIs
+description: Delete Asset API Reference for the Adobe Pro Audio and Video APIs
+keywords:
+  - Adobe Firefly Services
+  - Delete Asset
+  - API Reference
+  - Adobe Pro Audio and Video APIs
+  - Developer documentation
+  - API documentation
+layout: none
+---
+
+<RedoclyAPIBlock src="/firefly-services/docs/audio_delete_asset.json" width="600px" disableSidebar />

--- a/src/pages/audio_video/audio/api/get_enhancement.md
+++ b/src/pages/audio_video/audio/api/get_enhancement.md
@@ -1,0 +1,14 @@
+---
+title: Get Speech Enhancement - Adobe Pro Audio and Video APIs
+description: Get Speech Enhancement API Reference for the Adobe Pro Audio and Video APIs
+keywords:
+  - Adobe Firefly Services
+  - Get Speech Enhancement
+  - API Reference
+  - Adobe Pro Audio and Video APIs
+  - Developer documentation
+  - API documentation  
+layout: none
+---
+
+<RedoclyAPIBlock src="/firefly-services/docs/audio_get_enhancement.json" width="600px" disableSidebar />

--- a/src/pages/audio_video/audio/api/show_asset.md
+++ b/src/pages/audio_video/audio/api/show_asset.md
@@ -1,0 +1,14 @@
+---
+title: Show Asset - Adobe Pro Audio and Video APIs
+description: Show Asset API Reference for the Adobe Pro Audio and Video APIs
+keywords:
+  - Adobe Firefly Services
+  - Show Asset
+  - API Reference
+  - Adobe Pro Audio and Video APIs
+  - Developer documentation
+  - API documentation
+layout: none
+---
+
+<RedoclyAPIBlock src="/firefly-services/docs/audio_show_asset.json" width="600px" disableSidebar />

--- a/src/pages/audio_video/audio/index.md
+++ b/src/pages/audio_video/audio/index.md
@@ -1,0 +1,236 @@
+# Getting Started with the Enhance Speech API (Audio Services)
+
+The Enhance Speech API, part of Adobe Audio Services, enables rich workflow automation around audio post-production.
+
+## Overview
+
+This guide will demonstrate how to create enhanced (noise and echo-free) versions of your spoken-audio assets. To accomplish this, follow the steps below to learn how to create and upload data for an audio `Asset`, create a `SpeechEnhancement`, and download its data when ready.
+
+## Prerequisites
+
+To get started, you will need:
+
+- API credentials - these credentials were provided as part of the private beta in the form of a `client_id` and `client_secret`. You will need them available to get started.
+- An HTTP client, like [Postman](https://www.postman.com/).
+
+We also strongly encourage you to explore the [Enhance Speech within Adobe Podcast](https://podcast.adobe.com/enhance) site. The audio enhancement technology that backs this API is the same as the one available on the web, so exploring this will allow you to develop an intuition for how speech enhancement impacts audio, without writing any code!
+
+## Concepts
+
+Before diving into the API, it will be helpful to level-set on the following concepts:
+
+1. `Asset`: An `Asset` represents a file that contains audio that is compatible with speech enhancement. Currently, the Enhance Speech API only support audio-only files, like `.mp3` files. However, we might support other files that contain audio (like video files), in the future.
+2. `SpeechEnhancement`: A `SpeechEnhancement` represents an `Asset` that has been enhanced at a particular strength. As you can enhance an `Asset` at multiple strengths, it's possible to have many `SpeechEnhancement`s for a given `Asset`.
+
+## Enhance Speech API Walkthrough
+
+### Step 0: Obtain a valid access token
+
+Ensure you have reference to a valid access token. See the [Authentication Guide](../authentication/) for details on how to obtain such a token.
+
+### Step 1: Create an asset
+
+Before you can run speech enhancement on an `Asset`, you'll need to register a new `Asset` with the Enhance Speech API. To accomplish this, use the `POST /audio_services/v1/assets` endpoint.
+
+This endpoint requires the following information as a JSON request body:
+
+- `filename`:<br/>
+A filename (with extension) of the asset. We use this filename when naming the downloaded file for a downstream `SpeechEnhancement`.<br/>
+**Example:** `"earhart-aviation.mp3"`<br/>
+- `byte_size`:<br/>
+The number of bytes of the asset.<br/>
+**Example:** `59400`<br/>
+- `content_type`<br/>
+The content type of the asset.<br/>
+**Example:** `"audio/mpeg"`<br/>
+
+The `byte_size` and `content_type` are used to enable secure and verifiable direct uploads of your asset to our object store.
+
+#### API Request
+
+You can use the `curl` HTTP client to create an asset:
+
+```bash
+curl 'https://firefly-beta.adobe.io/audio_services/v1/assets'\
+--header 'x-api-key: {CLIENT_ID}'\
+--header 'Content-Type: application/json'\
+--header 'Authorization: Bearer {ACCESS_TOKEN}'\
+--data '{
+    "filename": "earhart-aviation.mp3",
+    "byte_size": 59400,
+    "content_type": "audio/mpeg"
+}'
+```
+
+If all goes well, you'll get a `201 Created` response with a payload like the following:
+
+```json
+{
+    "id": "3445d7a0-2513-4606-b37b-bff0034c0214",
+    "filename": "earhart-aviation.mp3",
+    "upload_url": "https://phonos-recordings-staging.s3-accelerate.amazonaws.com/Assets/3445d7a0-2513-4606-b37b-bff0034c0214?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAS2MU72M7ACPXX764%2F20240409%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240409T213836Z&X-Amz-Expires=43200&X-Amz-Security-Token=FwoGZXIvYXdzEPf%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaDMyjVxJyIRosE7smGSLJAWqfi8jqgkF0iiCYFU1nq3xAzNalFsrmbNnJRpWZvOSjGREvQftcLr%2FVgG9rjuz1cskXD3H8umxVLOS6oVmjHdt0wmaRtx5C6ZvGp8tW7BL%2F0hsuuU%2FmmG0n8QmmuQjA%2BfeaRkwR6Fgw85SryaPZUxzXhX9Y2BypyeBDX1H5JTPUYpZA0fAu1g9nYncsIjbNgnBJvr5e42gBnJZQSyAeeE3dA%2BK9btul5QapF5of4JTHXngkhLSBm819JD9iXRjRiUAUfoofGYfDhiiw5NawBjItFfJCqsABzKqETJ6q87zlAHajnVODPJgGowODSXrrqNd%2BTnV%2B73UXZTYKNukt&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost&X-Amz-Signature=45bad70aa97e89bf6120a7a0ec22b0dfc4771060922c50e1ec5c876f13252c49",
+    "status": "waiting_for_upload",
+    "created_at": "2024-04-09T21:38:36.872Z",
+    "updated_at": "2024-04-09T21:38:36.872Z",
+    "byte_size": 59400,
+    "content_type": "audio/mpeg",
+    "checksum": null
+}
+```
+
+As you can see in the API response, the `status` of this `Asset` is `waiting_for_upload`, which indicates it can't be used to  create `SpeechEnhancement`s until you upload data for the `Asset`.
+
+In the event that request parameters are structurally or semantically invalid, you'll get a `422` response. See the [API specification](../../api/) for details.
+
+### Step 2: Upload data for the asset
+
+In order to create `SpeechEnhancement`s for the `Asset`, the `Asset`'s `status` must be `ready_for_processing`. To do this, you need to upload valid data to the object store using the `upload_url` included in the response to `POST /audio_services/v1/assets`.
+
+You can accomplish this by making a `PUT` request to the `upload_url` with the `Asset`'s content and setting the `Content-Type` header to match the `content_type` provided when creating the `Asset`:
+
+```bash
+curl --request PUT 'https://phonos-recordings-staging.s3-accelerate.amazonaws.com/Assets/3445d7a0-2513-4606-b37b-bff0034c0214?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAS2MU72M7ACPXX764%2F20240409%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240409T213836Z&X-Amz-Expires=43200&X-Amz-Security-Token=FwoGZXIvYXdzEPf%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaDMyjVxJyIRosE7smGSLJAWqfi8jqgkF0iiCYFU1nq3xAzNalFsrmbNnJRpWZvOSjGREvQftcLr%2FVgG9rjuz1cskXD3H8umxVLOS6oVmjHdt0wmaRtx5C6ZvGp8tW7BL%2F0hsuuU%2FmmG0n8QmmuQjA%2BfeaRkwR6Fgw85SryaPZUxzXhX9Y2BypyeBDX1H5JTPUYpZA0fAu1g9nYncsIjbNgnBJvr5e42gBnJZQSyAeeE3dA%2BK9btul5QapF5of4JTHXngkhLSBm819JD9iXRjRiUAUfoofGYfDhiiw5NawBjItFfJCqsABzKqETJ6q87zlAHajnVODPJgGowODSXrrqNd%2BTnV%2B73UXZTYKNukt&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost&X-Amz-Signature=45bad70aa97e89bf6120a7a0ec22b0dfc4771060922c50e1ec5c876f13252c49'\
+--header 'Content-Type: audio/mpeg'\
+--data-binary '@/path/to/earhart-aviation.mp3'
+```
+
+If the upload request succeeds, you'll receive a `200` response with an empty body. If you receive a `400`-level response, double check that you are providing the exact same `Content-Type` and `Content-MD5` as supplied when creating the `Asset` via `POST /audio_services/v1/assets`.
+
+For more details on our object store's (AWS S3) `PUT` API, including links to language-specific S3 clients, please consult the [PutObject documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html).
+
+#### `upload_url` expiration window
+
+The presigned `upload_url` is *only valid for a few minutes*. Be certain to `PUT` to `upload_url` *as soon as it is returned in the API* (without any systematic delays).
+
+To receive a new `upload_url` for an `Asset`, call `GET /audio_services/v1/assets/:id` and use the new `upload_url` in the response:
+
+```bash
+curl --request GET 'https://firefly-beta.adobe.io/audio_services/v1/assets/3445d7a0-2513-4606-b37b-bff0034c0214'\
+--header 'x-api-key: {CLIENT_ID}'\
+--header 'Content-Type: application/json'\
+--header 'Authorization: Bearer {ACCESS_TOKEN}'
+```
+
+```json
+{
+    "id": "3445d7a0-2513-4606-b37b-bff0034c0214",
+    "filename": "earhart-aviation.mp3",
+    "upload_url": "https://phonos-recordings-staging.s3-accelerate.amazonaws.com/Assets/e971f261-b878-4f4e-b0b2-3f485847ff18?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAS2MU72M7KMGERYWU%2F20240409%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240409T223834Z&X-Amz-Expires=43200&X-Amz-Security-Token=FwoGZXIvYXdzEPj%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaDK9qYgyGpviWih6o0yLJAT9R%2Bh6EgpSttgs8uEC26fP3gwZvVKnblpk%2BlwPCqlQhR7YbTwZ0eGLVgWVxbKXTwk20TNrkmnL7DVxdm1%2BOQWhnqamyLSsxoSTAMlc7iLIbQua0mMDeVpty%2FOJQAZH7qxp6%2BD7DqO7M5o7DBQp9ZpQYIGqhntA5ykNUyRBJW3XABstDjVGoTm6epgYxJUKPxzjX2Swm%2BRyLBUykHH39VWWn1NEjdS6Cbbmd5txAbVYUpY9B1fM4THmOiMxYTf0X9LuqI3wQ7H%2FPjyjqhNewBjItrW7JkVjKx5%2Bsy%2BUtTajoNuVwnozge6PpPnCeQwvxaAJTzbwdISKaxCEuedm7&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost&X-Amz-Signature=554df03c538e36864db91d4b01db45ce8aba6dcf8ea31890cadf67df81dd9a90",
+    "status": "waiting_for_upload",
+    "created_at": "2024-04-09T22:37:12.541Z",
+    "updated_at": "2024-04-09T22:37:12.541Z",
+    "byte_size": 59400,
+    "content_type": "audio/mpeg",
+    "checksum": null
+}
+```
+
+#### Checking upload validity
+
+As an API client, the best way to ensure that not only did the `PUT` request above go through successfully, but was successfully registered by the [Enhance Speech API](../../api/), is to call the `GET /audio_services/v1/assets/:id` endpoint and ensure that `status` shows `ready_for_processing`. Once the `Asset` is `ready_for_processing`, an `upload_url` will no longer be displayed:
+
+```json
+{
+    "id": "3445d7a0-2513-4606-b37b-bff0034c0214",
+    "filename": "earhart-aviation.mp3",
+    "upload_url": null,
+    "status": "ready_for_processing",
+    "created_at": "2024-04-09T21:38:36.872Z",
+    "updated_at": "2024-04-09T22:37:03.129Z",
+    "byte_size": 59400,
+    "content_type": "audio/mpeg",
+    "checksum": "AWzJTRSXGy5JsL+Phh/cFA=="
+}
+```
+
+Now that the data has been uploaded to S3, a base64-encoded MD5 checksum of the uploaded data visible for the asset. You can use this checksum as a debugging datapoint to cross-reference data integrity between the Enhance Speech API and other storage systems.
+
+### Step 3: Create a speech enhancement
+
+Once you have an `Asset` that is `ready_for_processing`, you can create a `SpeechEnhancement` for it, at a given strength, using the `POST audio_services/v1/assets/:id/speech_enhancements` endpoint:
+
+```bash
+curl --location 'https://firefly-beta.adobe.io/audio_services/v1/assets/3445d7a0-2513-4606-b37b-bff0034c0214/speech_enhancements'\
+--header 'x-api-key: {CLIENT_ID}'\
+--header 'Content-Type: application/json'\
+--header 'Authorization: Bearer {ACCESS_TOKEN}'\
+--data '{
+    "strength": 93
+}'
+```
+
+Assuming that the `Asset` was `ready_for_processing` and the request is structurally valid, you should receive a [`202 Accepted`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202) response like the following:
+
+```json
+{
+    "strength": 93,
+    "id": "b877bc56-9c17-4efb-8eec-b5839cd7f555",
+    "download_url": null,
+    "asset_id": "3445d7a0-2513-4606-b37b-bff0034c0214",
+    "requested_processing_at": "2024-04-09T22:56:50.174Z",
+    "finished_processing_at": null,
+    "status": "queued",
+    "model_id": "v1"
+}
+```
+
+#### Understanding strength
+
+The strength parameter allows users to adjust the blend between the original and enhanced audio of the `Asset` when creating the `SpeechEnhancement`.
+
+**Usage Guidelines**
+
+- **Low Strength (0 - 50)**<br/>
+Preserves more of the original's subtle qualities. Useful for when your original asset is already high-quality or when you want to preserve more of the original acoustics and background.<br/>
+**Example:** Setting at 30 (30%) keeps most of the original audio with slight enhancement.<br/>
+
+- **High Strength (51 - 100)**<br/>
+Maximizes enhancement, reducing original audio presence.<br/>
+**Example:** At 100 (100%), the output is the fully enhanced version. Nearly all background is removed. Use this setting if you are exposing and mixing the Speech Enhancement in your own application.
+
+### Step 4: Poll to learn when the speech enhancement is complete
+
+As indicated by the `202 Accepted` response code, a `SpeechEnhancement` is not immediately acted upon by the API.
+
+Currently, a single `SpeechEnhancement` will be processed per API client - there is no parallel processing of speech enhancements.
+
+For example, if you create 5 assets via `POST /audio_services/v1/assets`, upload data for all of them, and then create 5 speech enhancements via `POST audio_services/v1/assets/:id/speech_enhancements`, only 1 of those speech enhancements will be processed at any given time (the order of processing will be from oldest to newest).
+
+To see the latest status of the newly created `SpeechEnhancement`, you can poll `GET audio_services/v1/assets/:asset-id/speech_enhancements/:speech-enhancement-id`:
+
+```bash
+curl 'https://firefly-beta.adobe.io/audio_services/v1/assets/3445d7a0-2513-4606-b37b-bff0034c0214/speech_enhancements/b877bc56-9c17-4efb-8eec-b5839cd7f555'\
+--header 'x-api-key: {CLIENT_ID}'\
+--header 'Authorization: Bearer {ACCESS_TOKEN}'
+```
+
+```json
+{
+    "strength": 93,
+    "id": "b877bc56-9c17-4efb-8eec-b5839cd7f555",
+    "download_url": "https://phonos-recordings-staging.s3-accelerate.amazonaws.com/Assets/c77ffc5f-aa1c-4db6-916e-99ae7978f76b/6757ba26-8de6-454f-a9d5-21a1bbc27eb3?response-content-disposition=attachment%3B%20filename%3D%22earhart-aviation-enhanced-92p.mp3%22%3B%20filename%2A%3DUTF-8%27%27earhart-aviation-enhanced-92p.mp3&response-content-type=audio%2Fmpeg&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAS2MU72M7HLP2GA42%2F20240423%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240423T210414Z&X-Amz-Expires=43200&X-Amz-Security-Token=FwoGZXIvYXdzEEYaDHSuaL9jaLiQpoCGzCLJASOmIUcZRk4wj9v0SJi098pCPXErSuLeak8WDsVQz9jOn82SciN8PFIli%2B5liuy8f%2BvukcQF5VJ3q3NRFgUf8%2FNeSqKeD8Y4Ci9SachcOQWBwYPAw0ZqbdaGNea99W4N5KVPJkfFM7L60a4%2B861CxVVVCh5wegNPqERkQ5uF%2Bxo6D3ZXSIevhGRfGOk5gj%2BWQCT1CDyC%2FYYoSZuLoSRK9S3cWSKcjqQqfYaBrqRv5xjeT9pmaEcHRMHcXGKF6u9pZ%2B6YPalushmhciiywKCxBjItCVY8PvebQUp0owuxf3Xt%2FCURh78fUej0d1n%2FQ3M9wiqZ5WRevzUwi3YivJB0&X-Amz-SignedHeaders=host&X-Amz-Signature=33d8c8ed1baa809168130636896581b7a832d2a1d1eee6a1246060ffd7e6221f",
+    "asset_id": "3445d7a0-2513-4606-b37b-bff0034c0214",
+    "requested_processing_at": "2024-04-09T22:56:50.174Z",
+    "finished_processing_at": "2024-04-09T22:56:51.675Z",
+    "status": "succeeded",
+    "model_id": "v1"
+}
+```
+
+The `status` of a `SpeechEnhancement` progresses from `queued` -> `processing` -> (`succeeded` OR `failed`).
+
+We don't often expect a `SpeechEnhancement` to fail (have a `status` of `failed`) -- this would likely indicate a server-side bug. However, in the rare event that it does happen, the API is transparent about this state.
+
+Once the `status` is `succeeded`, a non-null `download_url` is included in the response that enables the downloading of the speech enhancement to the API client.
+
+### Step 5: Download the speech enhancement
+
+To download the `SpeechEnhancement`, make a `GET` request to the `download_url` displayed above. This is a (short-lived) presigned URL that will enable the downloading of the enhanced audio from AWS S3. If the presigned URL has expired, make a new request to `GET audio_services/v1/assets/:asset-id/speech_enhancements/:speech-enhancement-id` to get a new presigned URL.
+
+```bash
+curl 'https://phonos-recordings-staging.s3-accelerate.amazonaws.com/Assets/c77ffc5f-aa1c-4db6-916e-99ae7978f76b/6757ba26-8de6-454f-a9d5-21a1bbc27eb3?response-content-disposition=attachment%3B%20filename%3D%22earhart-aviation-enhanced-92p.mp3%22%3B%20filename%2A%3DUTF-8%27%27earhart-aviation-enhanced-92p.mp3&response-content-type=audio%2Fmpeg&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAS2MU72M7HLP2GA42%2F20240423%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240423T210414Z&X-Amz-Expires=43200&X-Amz-Security-Token=FwoGZXIvYXdzEEYaDHSuaL9jaLiQpoCGzCLJASOmIUcZRk4wj9v0SJi098pCPXErSuLeak8WDsVQz9jOn82SciN8PFIli%2B5liuy8f%2BvukcQF5VJ3q3NRFgUf8%2FNeSqKeD8Y4Ci9SachcOQWBwYPAw0ZqbdaGNea99W4N5KVPJkfFM7L60a4%2B861CxVVVCh5wegNPqERkQ5uF%2Bxo6D3ZXSIevhGRfGOk5gj%2BWQCT1CDyC%2FYYoSZuLoSRK9S3cWSKcjqQqfYaBrqRv5xjeT9pmaEcHRMHcXGKF6u9pZ%2B6YPalushmhciiywKCxBjItCVY8PvebQUp0owuxf3Xt%2FCURh78fUej0d1n%2FQ3M9wiqZ5WRevzUwi3YivJB0&X-Amz-SignedHeaders=host&X-Amz-Signature=33d8c8ed1baa809168130636896581b7a832d2a1d1eee6a1246060ffd7e6221f' \ --remote-name --remote-header-name
+```
+
+The `--remote-name` and `--remote-header-name` options tells curl to use the `Content-Disposition` response header when naming the output file).
+
+This will result in a file named `"earhart-aviation-enhanced-93p.mp3"` saved at the your current working directory!

--- a/src/pages/audio_video/audio/usage-notes.md
+++ b/src/pages/audio_video/audio/usage-notes.md
@@ -1,0 +1,59 @@
+---
+title: Usage Notes - Adobe Pro Audio APIs
+description: Usage notes and rate limits for the Adobe Pro Audio APIs.
+contributors:
+  - https://github.com/hollyschinsky
+---
+
+# Audio Services - Usage Notes
+
+This guide details current support and usage limits for the Adobe Pro Audio APIs (Audio Services).
+
+## Input Audio Content Types
+
+The following `content_type` values are supported for use with the Enhance Speech API:
+
+- `audio/aac`
+- `audio/flac`
+- `audio/m4a`
+- `audio/mp4`
+- `audio/mpeg`
+- `audio/mpeg4-generic`
+- `audio/ogg`
+- `audio/opus`
+- `audio/vnd.dlna.adts`
+- `audio/vorbis`
+- `audio/wav`
+- `audio/x-aac`
+- `audio/x-aiff`
+- `audio/x-flac`
+- `audio/x-m4a`
+- `audio/x-wav`
+
+## Request Limits
+
+To ensure you enjoy equitable peak performance with the APIs, Adobe places limits on the volume, frequency, and concurrency of API calls, and monitors your API usage to proactively contact you and resolve any risks to API performance. We currently limit the rate of API requests per minute to the following:
+
+**Enhance Speech**: 
+
+- Creation endpoints (`POST /audio_services/v1/assets` and `POST /audio_services/v1/assets/:id/speech_enhancements`): 100 requests per minute
+- All other endpoints: 500 requests per minute
+- No daily request limit
+
+You may encounter a HTTP 429 ``Too Many Requests`` error if your usage exceeds either the per-minute, or per day limit. We recommend using the `'retry-after'` header to determine the number of seconds you should wait before trying again.
+
+<InlineAlert variant="warning" slots="text1" />
+
+Bear in mind that these usage limits apply to **your entire organization**<br/>
+
+<!-- <InlineAlert variant="info" slots="text1, text2, text3" />
+
+Bear in mind that the following usage limits apply to **your entire organization**:
+
+**4** requests **per minute**
+
+**9000** requests **per day**
+
+You may encounter a HTTP 429 "Too Many Requests" error if your usage exceeds either the per-minute, or per day limit. We recommend using the 'retry-after' header to determine the number of seconds you should wait before trying again.
+
+We appreciate that these limits may not be ideal for certain use cases. Please contact us at firefly-professional-services-support@adobe.com, so that we can partner with you on setting the optimal thresholds for your account. -->

--- a/src/pages/audio_video/index.md
+++ b/src/pages/audio_video/index.md
@@ -1,0 +1,69 @@
+---
+title: Overview - Adobe Pro Audio & Video APIs
+description: An overview of the Adobe Pro Audio & Video APIs
+keywords:
+  - Adobe Firefly Services
+  - Audio API
+  - Video API
+  - Firefly Developer documentation
+  - Adobe Audio API documentation
+  - Adobe Video API documentation
+  - Generative AI
+  - Enhance Speech API
+  - Application development with Firefly
+  - Adobe Firefly
+  - Firefly software development kit (SDK)
+  - JavaScript framework
+contributors:
+  - https://github.com/hollyschinsky
+  - https://github.com/nimithajalal
+hideBreadcrumbNav: true
+---
+
+<Hero slots="heading, text" background="rgb(64, 61, 221)"/>
+
+# Adobe Pro Audio & Video APIs - Firefly Services
+
+The Adobe Pro Audio and Video APIs allow you to easily integrate generative AI into your audio and video editing workflows, enabling rich workflow automation.
+
+## Overview
+
+This documentation provides instructions for the Adobe Audio and Video APIs.
+
+### Audio Services
+
+The Enhance Speech API gives you the ability to enhance voice recordings to sound as if they were recorded in a professional podcasting studio.
+
+Check out the [Getting Started Guide](./audio/) for a step-by-step walkthrough of using the Adobe Pro Audio APIs.
+
+### Video Services
+
+The Adobe Pro Video APIs are currently in private beta, with plans to be released in the near future.
+
+## Discover
+
+<DiscoverBlock slots="link, text" width="33%"/>
+
+[Getting Started with Audio Services](guides/)
+
+A step-by-step guide to getting started with the Adobe Pro Audio APIs.
+
+<DiscoverBlock slots="link, text" width="33%"/>
+
+[Getting Started with Video Services](guides/)
+
+A step-by-step guide to getting started with the Adobe Pro Video APIs (coming soon).
+
+<DiscoverBlock slots="link, text" width="33%"/>
+
+[Try the Audio Services APIs](./audio/api/)
+
+Try the Adobe Pro Audio APIs.
+
+<DiscoverBlock slots="link, text" width="33%"/>
+
+[Try the Video Services APIs](./video/index.md)
+
+Try the Adobe Pro Video APIs (coming soon).
+
+<br/><br/><br/><br/>

--- a/src/pages/audio_video/video/index.md
+++ b/src/pages/audio_video/video/index.md
@@ -1,0 +1,44 @@
+---
+title: Overview - Adobe Pro Audio & Video APIs
+description: An overview of the Adobe Pro Audio & Video APIs
+keywords:
+  - Adobe Firefly Services
+  - Pro Video APIs
+  - Firefly Developer documentation
+  - Adobe Video API documentation
+contributors:
+  - https://github.com/hollyschinsky
+hideBreadcrumbNav: true
+---
+
+# Video Services
+
+The Adobe Pro Video APIs are currently in private beta, with plans to be released in the near future.
+
+## Discover
+
+<DiscoverBlock slots="link, text" width="33%"/>
+
+[Getting Started with Audio Services](guides/)
+
+A step-by-step guide to getting started with the Adobe Pro Audio APIs.
+
+<DiscoverBlock slots="link, text" width="33%"/>
+
+[Getting Started with Video Services](guides/)
+
+A step-by-step guide to getting started with the Adobe Pro Video APIs (coming soon).
+
+<DiscoverBlock slots="link, text" width="33%"/>
+
+[Try the Audio Services APIs](./audio/api/)
+
+Try the Adobe Pro Audio APIs.
+
+<DiscoverBlock slots="link, text" width="33%"/>
+
+[Try the Video Services APIs](./video/index.md)
+
+Try the Adobe Pro Video APIs (coming soon).
+
+<br/><br/><br/><br/>

--- a/static/audio_create_asset.json
+++ b/static/audio_create_asset.json
@@ -1,0 +1,906 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+      "title": "Audio Services: Enhance Speech API",
+      "version": "v2"
+    },
+    "paths": {
+      "/v2/assets": {
+        "post": {
+          "summary": "Create an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Create an asset. You will receive an `uploadUrl` in the response, which you can use to upload the asset.",
+          "operationId": "createAsset",
+          "parameters": [
+
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "201": {
+              "description": "Asset created",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/asset"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Request missing required parameter fileName",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "request_missing_required_parameter": {
+                      "value": {
+                        "error_code": null,
+                        "message": "#/paths/~1v2~1assets/post/requestBody/content/application~1json/schema missing required parameters: fileName"
+                      },
+                      "summary": "Request missing a required parameter"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          },
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "fileName": {
+                      "type": "string",
+                      "description": "Name of the uploaded file (including file extension)."
+                    },
+                    "byteSize": {
+                      "type": "integer",
+                      "description": "Number of bytes of the file. Must match the value of the `Content-Length` header when uploading directly to S3."
+                    },
+                    "mediaType": {
+                      "type": "string",
+                      "description": "Content type of the file. Must match the value of `Content-Type` header when uploading directly to S3.",
+                      "enum": [
+                        "audio/aac",
+                        "audio/flac",
+                        "audio/m4a",
+                        "audio/mp4",
+                        "audio/mpeg",
+                        "audio/mpeg4-generic",
+                        "audio/ogg",
+                        "audio/opus",
+                        "audio/vnd.dlna.adts",
+                        "audio/vorbis",
+                        "audio/wav",
+                        "audio/x-aac",
+                        "audio/x-aiff",
+                        "audio/x-flac",
+                        "audio/x-m4a",
+                        "audio/x-wav"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "fileName",
+                    "byteSize",
+                    "mediaType"
+                  ]
+                },
+                "examples": {
+                  "name": {
+                    "summary": "summary",
+                    "value": {
+                      "fileName": "audio-file.mp3",
+                      "byteSize": 31005,
+                      "mediaType": "audio/mpeg"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/assets/{id}": {
+        "get": {
+          "summary": "Show an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Retrieve information about a specific asset identified by its `id`. This endpoint allows you to view the details of an asset that was previously created using the `POST /v2/assets` endpoint.",
+          "operationId": "getAsset",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired asset.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "200": {
+              "description": "Asset found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/asset"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "delete": {
+          "summary": "Delete an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Delete the asset with the specified `id`.",
+          "operationId": "deleteAsset",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired asset.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "204": {
+              "description": "Asset deleted",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_deleted": {
+                      "summary": "Asset and any speech enhancements successfully deleted"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/speech-enhancements": {
+        "post": {
+          "summary": "Create a speech enhancement",
+          "tags": [
+            "Speech Enhancements"
+          ],
+          "description": "This endpoint allows you to run speech enhancement, at a specific `strength`, on an asset (identified by `input.uploadId`).",
+          "operationId": "createSpeechEnhancement",
+          "parameters": [
+
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "202": {
+              "description": "Speech enhancement accepted",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/speech_enhancement"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Speech enhancement not created",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "speech_enhancement_already_exists": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Speech enhancement already exists for specified asset, model and strength."
+                      },
+                      "summary": "Speech enhancement already exists"
+                    },
+                    "non_ready_asset": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Asset has not been uploaded yet"
+                      },
+                      "summary": "Asset has not had a file uploaded"
+                    },
+                    "non_enhanceable_asset": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Asset is not enhanceable"
+                      },
+                      "summary": "Asset has a file, but enhancing has failed unexpectedly",
+                      "description": "Further requests to create enhancements for the same asset will fail. If the client is sure the file is enhanceable, they can create a new asset and try again"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          },
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "strength": {
+                      "type": "number",
+                      "minimum": 1,
+                      "maximum": 100,
+                      "example": 90,
+                      "description": "Percentage strength of speech enhancement."
+                    },
+                    "input": {
+                      "type": "object",
+                      "properties": {
+                        "uploadId": {
+                          "type": "string",
+                          "example": "audio-services:asset:91c8c3bf-be89-4284-a4f3-cfda5352fc4c",
+                          "description": "ID of the asset with identifying prefix to create a speech enhancement for."
+                        }
+                      },
+                      "required": [
+                        "uploadId"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "strength",
+                    "input"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/speech-enhancements/{id}": {
+        "get": {
+          "summary": "Get a speech enhancement",
+          "tags": [
+            "Speech Enhancements"
+          ],
+          "description": "Retrieve information about a speech enhancement for an asset, identified by `id`. This endpoint allows you to view the details of a speech enhancement that was previously created using the `POST /v2/speech-enhancements` endpoint.",
+          "operationId": "getSpeechEnhancement",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired speech enhancement.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "200": {
+              "description": "Speech enhancement found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/speech_enhancement"
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Speech enhancement not found",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "speech_enhancement_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Speech enhancement not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "servers": [
+      {
+        "url": "https://firefly-api-enterprise-stage.adobe.io/audio_services"
+      }
+    ],
+    "components": {
+      "securitySchemes": {
+        "bearer_auth": {
+          "type": "http",
+          "scheme": "bearer"
+        },
+        "api_key": {
+          "type": "apiKey",
+          "in": "header",
+          "name": "X-Api-Key"
+        }
+      },
+      "schemas": {
+        "asset": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "bcab9f0c-f740-41f1-990e-c21f2cae6af0",
+              "description": "Unique ID of the asset."
+            },
+            "fileName": {
+              "type": "string",
+              "nullable": false,
+              "example": "audio-file.mp3",
+              "description": "Name of uploaded file (including file extension)."
+            },
+            "uploadUrl": {
+              "type": "string",
+              "nullable": true,
+              "example": "https://bucket.s3-accelerate.amazonaws.com/Assets/...",
+              "description": "Pre-signed S3 URL to upload file to. Expires after 5 minutes. See guide and S3 [`PutObject` docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html)"
+            },
+            "status": {
+              "type": "string",
+              "nullable": false,
+              "enum": [
+                "waiting_for_upload",
+                "ready_for_processing",
+                "invalid_upload"
+              ],
+              "example": "waiting_for_upload",
+              "description": "Indicates the upload status of the Asset. The original status is `waiting_for_upload` and, after successfully being uploaded to S3, is `ready_for_processing`. An asset is `upload_invalid` if the underlying file is deemed unacceptable."
+            },
+            "byteSize": {
+              "type": "integer",
+              "nullable": true,
+              "minimum": 0,
+              "example": 31005,
+              "description": "Number of bytes of the file."
+            },
+            "mediaType": {
+              "type": "string",
+              "nullable": true,
+              "example": "audio/mpeg",
+              "description": "Media type of the file."
+            },
+            "checksum": {
+              "type": "string",
+              "nullable": true,
+              "example": "6gH7SfirkyEWPA+QeOuJjQ==",
+              "description": "Base64 encoded MD5 checksum of the uploaded file."
+            },
+            "updatedAt": {
+              "type": "string",
+              "nullable": false,
+              "format": "date-time",
+              "description": "Datetime of when the asset was last updated."
+            },
+            "createdAt": {
+              "type": "string",
+              "nullable": false,
+              "format": "date-time",
+              "description": "Datetime of when the asset was created."
+            }
+          },
+          "required": [
+            "id",
+            "fileName",
+            "uploadUrl",
+            "status",
+            "byteSize",
+            "mediaType",
+            "checksum",
+            "updatedAt",
+            "createdAt"
+          ]
+        },
+        "error": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "nullable": false
+            },
+            "error_code": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "required": [
+            "message",
+            "error_code"
+          ]
+        },
+        "speech_enhancement": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "d7748c6d-4be9-41e7-a6a8-d4138eaa8219",
+              "description": "Unique ID of the speech enhancement."
+            },
+            "strength": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "nullable": false,
+              "example": 90,
+              "description": "Percentage strength of speech enhancement."
+            },
+            "modelId": {
+              "type": "string",
+              "nullable": false,
+              "example": "v1",
+              "description": "Unique identifier of the model that performs speech enhancement."
+            },
+            "assetId": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "bcab9f0c-f740-41f1-990e-c21f2cae6af0",
+              "description": "Unique ID of the asset of the speech enhancement."
+            },
+            "requestedProcessingAt": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": false,
+              "description": "Datetime of when the speech enhancement was created."
+            },
+            "finishedProcessingAt": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true,
+              "description": "Datetime of when the speech enhancement was completed."
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "failed",
+                "succeeded",
+                "processing",
+                "queued"
+              ],
+              "nullable": false,
+              "example": "processing",
+              "description": "Indicates the processing status of the speech enhancement."
+            },
+            "output": {
+              "type": "object",
+              "nullable": true,
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "nullable": true,
+                  "example": "https://bucket.s3-accelerate.amazonaws.com/Assets/...",
+                  "description": "URL that provides access to download the speech enhancement as a file. Only available when the status is `succeeded`."
+                }
+              }
+            }
+          },
+          "required": [
+            "id",
+            "strength",
+            "modelId",
+            "assetId",
+            "requestedProcessingAt",
+            "finishedProcessingAt",
+            "status",
+            "output"
+          ]
+        }
+      }
+    }
+  }

--- a/static/audio_create_enhancement.json
+++ b/static/audio_create_enhancement.json
@@ -1,0 +1,906 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+      "title": "Audio Services: Enhance Speech API",
+      "version": "v2"
+    },
+    "paths": {
+      "/v2/assets": {
+        "post": {
+          "summary": "Create an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Create an asset. You will receive an `uploadUrl` in the response, which you can use to upload the asset.",
+          "operationId": "createAsset",
+          "parameters": [
+
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "201": {
+              "description": "Asset created",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/asset"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Request missing required parameter fileName",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "request_missing_required_parameter": {
+                      "value": {
+                        "error_code": null,
+                        "message": "#/paths/~1v2~1assets/post/requestBody/content/application~1json/schema missing required parameters: fileName"
+                      },
+                      "summary": "Request missing a required parameter"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          },
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "fileName": {
+                      "type": "string",
+                      "description": "Name of the uploaded file (including file extension)."
+                    },
+                    "byteSize": {
+                      "type": "integer",
+                      "description": "Number of bytes of the file. Must match the value of the `Content-Length` header when uploading directly to S3."
+                    },
+                    "mediaType": {
+                      "type": "string",
+                      "description": "Content type of the file. Must match the value of `Content-Type` header when uploading directly to S3.",
+                      "enum": [
+                        "audio/aac",
+                        "audio/flac",
+                        "audio/m4a",
+                        "audio/mp4",
+                        "audio/mpeg",
+                        "audio/mpeg4-generic",
+                        "audio/ogg",
+                        "audio/opus",
+                        "audio/vnd.dlna.adts",
+                        "audio/vorbis",
+                        "audio/wav",
+                        "audio/x-aac",
+                        "audio/x-aiff",
+                        "audio/x-flac",
+                        "audio/x-m4a",
+                        "audio/x-wav"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "fileName",
+                    "byteSize",
+                    "mediaType"
+                  ]
+                },
+                "examples": {
+                  "name": {
+                    "summary": "summary",
+                    "value": {
+                      "fileName": "audio-file.mp3",
+                      "byteSize": 31005,
+                      "mediaType": "audio/mpeg"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/assets/{id}": {
+        "get": {
+          "summary": "Show an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Retrieve information about a specific asset identified by its `id`. This endpoint allows you to view the details of an asset that was previously created using the `POST /v2/assets` endpoint.",
+          "operationId": "getAsset",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired asset.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "200": {
+              "description": "Asset found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/asset"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "delete": {
+          "summary": "Delete an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Delete the asset with the specified `id`.",
+          "operationId": "deleteAsset",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired asset.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "204": {
+              "description": "Asset deleted",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_deleted": {
+                      "summary": "Asset and any speech enhancements successfully deleted"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/speech-enhancements": {
+        "post": {
+          "summary": "Create a speech enhancement",
+          "tags": [
+            "Speech Enhancements"
+          ],
+          "description": "This endpoint allows you to run speech enhancement, at a specific `strength`, on an asset (identified by `input.uploadId`).",
+          "operationId": "createSpeechEnhancement",
+          "parameters": [
+
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "202": {
+              "description": "Speech enhancement accepted",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/speech_enhancement"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Speech enhancement not created",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "speech_enhancement_already_exists": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Speech enhancement already exists for specified asset, model and strength."
+                      },
+                      "summary": "Speech enhancement already exists"
+                    },
+                    "non_ready_asset": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Asset has not been uploaded yet"
+                      },
+                      "summary": "Asset has not had a file uploaded"
+                    },
+                    "non_enhanceable_asset": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Asset is not enhanceable"
+                      },
+                      "summary": "Asset has a file, but enhancing has failed unexpectedly",
+                      "description": "Further requests to create enhancements for the same asset will fail. If the client is sure the file is enhanceable, they can create a new asset and try again"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          },
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "strength": {
+                      "type": "number",
+                      "minimum": 1,
+                      "maximum": 100,
+                      "example": 90,
+                      "description": "Percentage strength of speech enhancement."
+                    },
+                    "input": {
+                      "type": "object",
+                      "properties": {
+                        "uploadId": {
+                          "type": "string",
+                          "example": "audio-services:asset:91c8c3bf-be89-4284-a4f3-cfda5352fc4c",
+                          "description": "ID of the asset with identifying prefix to create a speech enhancement for."
+                        }
+                      },
+                      "required": [
+                        "uploadId"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "strength",
+                    "input"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/speech-enhancements/{id}": {
+        "get": {
+          "summary": "Get a speech enhancement",
+          "tags": [
+            "Speech Enhancements"
+          ],
+          "description": "Retrieve information about a speech enhancement for an asset, identified by `id`. This endpoint allows you to view the details of a speech enhancement that was previously created using the `POST /v2/speech-enhancements` endpoint.",
+          "operationId": "getSpeechEnhancement",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired speech enhancement.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "200": {
+              "description": "Speech enhancement found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/speech_enhancement"
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Speech enhancement not found",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "speech_enhancement_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Speech enhancement not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "servers": [
+      {
+        "url": "https://firefly-api-enterprise-stage.adobe.io/audio_services"
+      }
+    ],
+    "components": {
+      "securitySchemes": {
+        "bearer_auth": {
+          "type": "http",
+          "scheme": "bearer"
+        },
+        "api_key": {
+          "type": "apiKey",
+          "in": "header",
+          "name": "X-Api-Key"
+        }
+      },
+      "schemas": {
+        "asset": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "bcab9f0c-f740-41f1-990e-c21f2cae6af0",
+              "description": "Unique ID of the asset."
+            },
+            "fileName": {
+              "type": "string",
+              "nullable": false,
+              "example": "audio-file.mp3",
+              "description": "Name of uploaded file (including file extension)."
+            },
+            "uploadUrl": {
+              "type": "string",
+              "nullable": true,
+              "example": "https://bucket.s3-accelerate.amazonaws.com/Assets/...",
+              "description": "Pre-signed S3 URL to upload file to. Expires after 5 minutes. See guide and S3 [`PutObject` docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html)"
+            },
+            "status": {
+              "type": "string",
+              "nullable": false,
+              "enum": [
+                "waiting_for_upload",
+                "ready_for_processing",
+                "invalid_upload"
+              ],
+              "example": "waiting_for_upload",
+              "description": "Indicates the upload status of the Asset. The original status is `waiting_for_upload` and, after successfully being uploaded to S3, is `ready_for_processing`. An asset is `upload_invalid` if the underlying file is deemed unacceptable."
+            },
+            "byteSize": {
+              "type": "integer",
+              "nullable": true,
+              "minimum": 0,
+              "example": 31005,
+              "description": "Number of bytes of the file."
+            },
+            "mediaType": {
+              "type": "string",
+              "nullable": true,
+              "example": "audio/mpeg",
+              "description": "Media type of the file."
+            },
+            "checksum": {
+              "type": "string",
+              "nullable": true,
+              "example": "6gH7SfirkyEWPA+QeOuJjQ==",
+              "description": "Base64 encoded MD5 checksum of the uploaded file."
+            },
+            "updatedAt": {
+              "type": "string",
+              "nullable": false,
+              "format": "date-time",
+              "description": "Datetime of when the asset was last updated."
+            },
+            "createdAt": {
+              "type": "string",
+              "nullable": false,
+              "format": "date-time",
+              "description": "Datetime of when the asset was created."
+            }
+          },
+          "required": [
+            "id",
+            "fileName",
+            "uploadUrl",
+            "status",
+            "byteSize",
+            "mediaType",
+            "checksum",
+            "updatedAt",
+            "createdAt"
+          ]
+        },
+        "error": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "nullable": false
+            },
+            "error_code": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "required": [
+            "message",
+            "error_code"
+          ]
+        },
+        "speech_enhancement": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "d7748c6d-4be9-41e7-a6a8-d4138eaa8219",
+              "description": "Unique ID of the speech enhancement."
+            },
+            "strength": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "nullable": false,
+              "example": 90,
+              "description": "Percentage strength of speech enhancement."
+            },
+            "modelId": {
+              "type": "string",
+              "nullable": false,
+              "example": "v1",
+              "description": "Unique identifier of the model that performs speech enhancement."
+            },
+            "assetId": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "bcab9f0c-f740-41f1-990e-c21f2cae6af0",
+              "description": "Unique ID of the asset of the speech enhancement."
+            },
+            "requestedProcessingAt": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": false,
+              "description": "Datetime of when the speech enhancement was created."
+            },
+            "finishedProcessingAt": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true,
+              "description": "Datetime of when the speech enhancement was completed."
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "failed",
+                "succeeded",
+                "processing",
+                "queued"
+              ],
+              "nullable": false,
+              "example": "processing",
+              "description": "Indicates the processing status of the speech enhancement."
+            },
+            "output": {
+              "type": "object",
+              "nullable": true,
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "nullable": true,
+                  "example": "https://bucket.s3-accelerate.amazonaws.com/Assets/...",
+                  "description": "URL that provides access to download the speech enhancement as a file. Only available when the status is `succeeded`."
+                }
+              }
+            }
+          },
+          "required": [
+            "id",
+            "strength",
+            "modelId",
+            "assetId",
+            "requestedProcessingAt",
+            "finishedProcessingAt",
+            "status",
+            "output"
+          ]
+        }
+      }
+    }
+  }

--- a/static/audio_delete_asset.json
+++ b/static/audio_delete_asset.json
@@ -1,0 +1,906 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+      "title": "Audio Services: Enhance Speech API",
+      "version": "v2"
+    },
+    "paths": {
+      "/v2/assets": {
+        "post": {
+          "summary": "Create an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Create an asset. You will receive an `uploadUrl` in the response, which you can use to upload the asset.",
+          "operationId": "createAsset",
+          "parameters": [
+
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "201": {
+              "description": "Asset created",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/asset"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Request missing required parameter fileName",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "request_missing_required_parameter": {
+                      "value": {
+                        "error_code": null,
+                        "message": "#/paths/~1v2~1assets/post/requestBody/content/application~1json/schema missing required parameters: fileName"
+                      },
+                      "summary": "Request missing a required parameter"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          },
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "fileName": {
+                      "type": "string",
+                      "description": "Name of the uploaded file (including file extension)."
+                    },
+                    "byteSize": {
+                      "type": "integer",
+                      "description": "Number of bytes of the file. Must match the value of the `Content-Length` header when uploading directly to S3."
+                    },
+                    "mediaType": {
+                      "type": "string",
+                      "description": "Content type of the file. Must match the value of `Content-Type` header when uploading directly to S3.",
+                      "enum": [
+                        "audio/aac",
+                        "audio/flac",
+                        "audio/m4a",
+                        "audio/mp4",
+                        "audio/mpeg",
+                        "audio/mpeg4-generic",
+                        "audio/ogg",
+                        "audio/opus",
+                        "audio/vnd.dlna.adts",
+                        "audio/vorbis",
+                        "audio/wav",
+                        "audio/x-aac",
+                        "audio/x-aiff",
+                        "audio/x-flac",
+                        "audio/x-m4a",
+                        "audio/x-wav"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "fileName",
+                    "byteSize",
+                    "mediaType"
+                  ]
+                },
+                "examples": {
+                  "name": {
+                    "summary": "summary",
+                    "value": {
+                      "fileName": "audio-file.mp3",
+                      "byteSize": 31005,
+                      "mediaType": "audio/mpeg"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/assets/{id}": {
+        "get": {
+          "summary": "Show an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Retrieve information about a specific asset identified by its `id`. This endpoint allows you to view the details of an asset that was previously created using the `POST /v2/assets` endpoint.",
+          "operationId": "getAsset",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired asset.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "200": {
+              "description": "Asset found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/asset"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "delete": {
+          "summary": "Delete an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Delete the asset with the specified `id`.",
+          "operationId": "deleteAsset",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired asset.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "204": {
+              "description": "Asset deleted",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_deleted": {
+                      "summary": "Asset and any speech enhancements successfully deleted"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/speech-enhancements": {
+        "post": {
+          "summary": "Create a speech enhancement",
+          "tags": [
+            "Speech Enhancements"
+          ],
+          "description": "This endpoint allows you to run speech enhancement, at a specific `strength`, on an asset (identified by `input.uploadId`).",
+          "operationId": "createSpeechEnhancement",
+          "parameters": [
+
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "202": {
+              "description": "Speech enhancement accepted",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/speech_enhancement"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Speech enhancement not created",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "speech_enhancement_already_exists": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Speech enhancement already exists for specified asset, model and strength."
+                      },
+                      "summary": "Speech enhancement already exists"
+                    },
+                    "non_ready_asset": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Asset has not been uploaded yet"
+                      },
+                      "summary": "Asset has not had a file uploaded"
+                    },
+                    "non_enhanceable_asset": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Asset is not enhanceable"
+                      },
+                      "summary": "Asset has a file, but enhancing has failed unexpectedly",
+                      "description": "Further requests to create enhancements for the same asset will fail. If the client is sure the file is enhanceable, they can create a new asset and try again"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          },
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "strength": {
+                      "type": "number",
+                      "minimum": 1,
+                      "maximum": 100,
+                      "example": 90,
+                      "description": "Percentage strength of speech enhancement."
+                    },
+                    "input": {
+                      "type": "object",
+                      "properties": {
+                        "uploadId": {
+                          "type": "string",
+                          "example": "audio-services:asset:91c8c3bf-be89-4284-a4f3-cfda5352fc4c",
+                          "description": "ID of the asset with identifying prefix to create a speech enhancement for."
+                        }
+                      },
+                      "required": [
+                        "uploadId"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "strength",
+                    "input"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/speech-enhancements/{id}": {
+        "get": {
+          "summary": "Get a speech enhancement",
+          "tags": [
+            "Speech Enhancements"
+          ],
+          "description": "Retrieve information about a speech enhancement for an asset, identified by `id`. This endpoint allows you to view the details of a speech enhancement that was previously created using the `POST /v2/speech-enhancements` endpoint.",
+          "operationId": "getSpeechEnhancement",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired speech enhancement.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "200": {
+              "description": "Speech enhancement found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/speech_enhancement"
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Speech enhancement not found",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "speech_enhancement_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Speech enhancement not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "servers": [
+      {
+        "url": "https://firefly-api-enterprise-stage.adobe.io/audio_services"
+      }
+    ],
+    "components": {
+      "securitySchemes": {
+        "bearer_auth": {
+          "type": "http",
+          "scheme": "bearer"
+        },
+        "api_key": {
+          "type": "apiKey",
+          "in": "header",
+          "name": "X-Api-Key"
+        }
+      },
+      "schemas": {
+        "asset": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "bcab9f0c-f740-41f1-990e-c21f2cae6af0",
+              "description": "Unique ID of the asset."
+            },
+            "fileName": {
+              "type": "string",
+              "nullable": false,
+              "example": "audio-file.mp3",
+              "description": "Name of uploaded file (including file extension)."
+            },
+            "uploadUrl": {
+              "type": "string",
+              "nullable": true,
+              "example": "https://bucket.s3-accelerate.amazonaws.com/Assets/...",
+              "description": "Pre-signed S3 URL to upload file to. Expires after 5 minutes. See guide and S3 [`PutObject` docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html)"
+            },
+            "status": {
+              "type": "string",
+              "nullable": false,
+              "enum": [
+                "waiting_for_upload",
+                "ready_for_processing",
+                "invalid_upload"
+              ],
+              "example": "waiting_for_upload",
+              "description": "Indicates the upload status of the Asset. The original status is `waiting_for_upload` and, after successfully being uploaded to S3, is `ready_for_processing`. An asset is `upload_invalid` if the underlying file is deemed unacceptable."
+            },
+            "byteSize": {
+              "type": "integer",
+              "nullable": true,
+              "minimum": 0,
+              "example": 31005,
+              "description": "Number of bytes of the file."
+            },
+            "mediaType": {
+              "type": "string",
+              "nullable": true,
+              "example": "audio/mpeg",
+              "description": "Media type of the file."
+            },
+            "checksum": {
+              "type": "string",
+              "nullable": true,
+              "example": "6gH7SfirkyEWPA+QeOuJjQ==",
+              "description": "Base64 encoded MD5 checksum of the uploaded file."
+            },
+            "updatedAt": {
+              "type": "string",
+              "nullable": false,
+              "format": "date-time",
+              "description": "Datetime of when the asset was last updated."
+            },
+            "createdAt": {
+              "type": "string",
+              "nullable": false,
+              "format": "date-time",
+              "description": "Datetime of when the asset was created."
+            }
+          },
+          "required": [
+            "id",
+            "fileName",
+            "uploadUrl",
+            "status",
+            "byteSize",
+            "mediaType",
+            "checksum",
+            "updatedAt",
+            "createdAt"
+          ]
+        },
+        "error": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "nullable": false
+            },
+            "error_code": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "required": [
+            "message",
+            "error_code"
+          ]
+        },
+        "speech_enhancement": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "d7748c6d-4be9-41e7-a6a8-d4138eaa8219",
+              "description": "Unique ID of the speech enhancement."
+            },
+            "strength": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "nullable": false,
+              "example": 90,
+              "description": "Percentage strength of speech enhancement."
+            },
+            "modelId": {
+              "type": "string",
+              "nullable": false,
+              "example": "v1",
+              "description": "Unique identifier of the model that performs speech enhancement."
+            },
+            "assetId": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "bcab9f0c-f740-41f1-990e-c21f2cae6af0",
+              "description": "Unique ID of the asset of the speech enhancement."
+            },
+            "requestedProcessingAt": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": false,
+              "description": "Datetime of when the speech enhancement was created."
+            },
+            "finishedProcessingAt": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true,
+              "description": "Datetime of when the speech enhancement was completed."
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "failed",
+                "succeeded",
+                "processing",
+                "queued"
+              ],
+              "nullable": false,
+              "example": "processing",
+              "description": "Indicates the processing status of the speech enhancement."
+            },
+            "output": {
+              "type": "object",
+              "nullable": true,
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "nullable": true,
+                  "example": "https://bucket.s3-accelerate.amazonaws.com/Assets/...",
+                  "description": "URL that provides access to download the speech enhancement as a file. Only available when the status is `succeeded`."
+                }
+              }
+            }
+          },
+          "required": [
+            "id",
+            "strength",
+            "modelId",
+            "assetId",
+            "requestedProcessingAt",
+            "finishedProcessingAt",
+            "status",
+            "output"
+          ]
+        }
+      }
+    }
+  }

--- a/static/audio_get_enhancement.json
+++ b/static/audio_get_enhancement.json
@@ -1,0 +1,906 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+      "title": "Audio Services: Enhance Speech API",
+      "version": "v2"
+    },
+    "paths": {
+      "/v2/assets": {
+        "post": {
+          "summary": "Create an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Create an asset. You will receive an `uploadUrl` in the response, which you can use to upload the asset.",
+          "operationId": "createAsset",
+          "parameters": [
+
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "201": {
+              "description": "Asset created",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/asset"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Request missing required parameter fileName",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "request_missing_required_parameter": {
+                      "value": {
+                        "error_code": null,
+                        "message": "#/paths/~1v2~1assets/post/requestBody/content/application~1json/schema missing required parameters: fileName"
+                      },
+                      "summary": "Request missing a required parameter"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          },
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "fileName": {
+                      "type": "string",
+                      "description": "Name of the uploaded file (including file extension)."
+                    },
+                    "byteSize": {
+                      "type": "integer",
+                      "description": "Number of bytes of the file. Must match the value of the `Content-Length` header when uploading directly to S3."
+                    },
+                    "mediaType": {
+                      "type": "string",
+                      "description": "Content type of the file. Must match the value of `Content-Type` header when uploading directly to S3.",
+                      "enum": [
+                        "audio/aac",
+                        "audio/flac",
+                        "audio/m4a",
+                        "audio/mp4",
+                        "audio/mpeg",
+                        "audio/mpeg4-generic",
+                        "audio/ogg",
+                        "audio/opus",
+                        "audio/vnd.dlna.adts",
+                        "audio/vorbis",
+                        "audio/wav",
+                        "audio/x-aac",
+                        "audio/x-aiff",
+                        "audio/x-flac",
+                        "audio/x-m4a",
+                        "audio/x-wav"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "fileName",
+                    "byteSize",
+                    "mediaType"
+                  ]
+                },
+                "examples": {
+                  "name": {
+                    "summary": "summary",
+                    "value": {
+                      "fileName": "audio-file.mp3",
+                      "byteSize": 31005,
+                      "mediaType": "audio/mpeg"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/assets/{id}": {
+        "get": {
+          "summary": "Show an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Retrieve information about a specific asset identified by its `id`. This endpoint allows you to view the details of an asset that was previously created using the `POST /v2/assets` endpoint.",
+          "operationId": "getAsset",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired asset.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "200": {
+              "description": "Asset found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/asset"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "delete": {
+          "summary": "Delete an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Delete the asset with the specified `id`.",
+          "operationId": "deleteAsset",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired asset.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "204": {
+              "description": "Asset deleted",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_deleted": {
+                      "summary": "Asset and any speech enhancements successfully deleted"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/speech-enhancements": {
+        "post": {
+          "summary": "Create a speech enhancement",
+          "tags": [
+            "Speech Enhancements"
+          ],
+          "description": "This endpoint allows you to run speech enhancement, at a specific `strength`, on an asset (identified by `input.uploadId`).",
+          "operationId": "createSpeechEnhancement",
+          "parameters": [
+
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "202": {
+              "description": "Speech enhancement accepted",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/speech_enhancement"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Speech enhancement not created",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "speech_enhancement_already_exists": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Speech enhancement already exists for specified asset, model and strength."
+                      },
+                      "summary": "Speech enhancement already exists"
+                    },
+                    "non_ready_asset": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Asset has not been uploaded yet"
+                      },
+                      "summary": "Asset has not had a file uploaded"
+                    },
+                    "non_enhanceable_asset": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Asset is not enhanceable"
+                      },
+                      "summary": "Asset has a file, but enhancing has failed unexpectedly",
+                      "description": "Further requests to create enhancements for the same asset will fail. If the client is sure the file is enhanceable, they can create a new asset and try again"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          },
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "strength": {
+                      "type": "number",
+                      "minimum": 1,
+                      "maximum": 100,
+                      "example": 90,
+                      "description": "Percentage strength of speech enhancement."
+                    },
+                    "input": {
+                      "type": "object",
+                      "properties": {
+                        "uploadId": {
+                          "type": "string",
+                          "example": "audio-services:asset:91c8c3bf-be89-4284-a4f3-cfda5352fc4c",
+                          "description": "ID of the asset with identifying prefix to create a speech enhancement for."
+                        }
+                      },
+                      "required": [
+                        "uploadId"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "strength",
+                    "input"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/speech-enhancements/{id}": {
+        "get": {
+          "summary": "Get a speech enhancement",
+          "tags": [
+            "Speech Enhancements"
+          ],
+          "description": "Retrieve information about a speech enhancement for an asset, identified by `id`. This endpoint allows you to view the details of a speech enhancement that was previously created using the `POST /v2/speech-enhancements` endpoint.",
+          "operationId": "getSpeechEnhancement",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired speech enhancement.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "200": {
+              "description": "Speech enhancement found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/speech_enhancement"
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Speech enhancement not found",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "speech_enhancement_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Speech enhancement not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "servers": [
+      {
+        "url": "https://firefly-api-enterprise-stage.adobe.io/audio_services"
+      }
+    ],
+    "components": {
+      "securitySchemes": {
+        "bearer_auth": {
+          "type": "http",
+          "scheme": "bearer"
+        },
+        "api_key": {
+          "type": "apiKey",
+          "in": "header",
+          "name": "X-Api-Key"
+        }
+      },
+      "schemas": {
+        "asset": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "bcab9f0c-f740-41f1-990e-c21f2cae6af0",
+              "description": "Unique ID of the asset."
+            },
+            "fileName": {
+              "type": "string",
+              "nullable": false,
+              "example": "audio-file.mp3",
+              "description": "Name of uploaded file (including file extension)."
+            },
+            "uploadUrl": {
+              "type": "string",
+              "nullable": true,
+              "example": "https://bucket.s3-accelerate.amazonaws.com/Assets/...",
+              "description": "Pre-signed S3 URL to upload file to. Expires after 5 minutes. See guide and S3 [`PutObject` docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html)"
+            },
+            "status": {
+              "type": "string",
+              "nullable": false,
+              "enum": [
+                "waiting_for_upload",
+                "ready_for_processing",
+                "invalid_upload"
+              ],
+              "example": "waiting_for_upload",
+              "description": "Indicates the upload status of the Asset. The original status is `waiting_for_upload` and, after successfully being uploaded to S3, is `ready_for_processing`. An asset is `upload_invalid` if the underlying file is deemed unacceptable."
+            },
+            "byteSize": {
+              "type": "integer",
+              "nullable": true,
+              "minimum": 0,
+              "example": 31005,
+              "description": "Number of bytes of the file."
+            },
+            "mediaType": {
+              "type": "string",
+              "nullable": true,
+              "example": "audio/mpeg",
+              "description": "Media type of the file."
+            },
+            "checksum": {
+              "type": "string",
+              "nullable": true,
+              "example": "6gH7SfirkyEWPA+QeOuJjQ==",
+              "description": "Base64 encoded MD5 checksum of the uploaded file."
+            },
+            "updatedAt": {
+              "type": "string",
+              "nullable": false,
+              "format": "date-time",
+              "description": "Datetime of when the asset was last updated."
+            },
+            "createdAt": {
+              "type": "string",
+              "nullable": false,
+              "format": "date-time",
+              "description": "Datetime of when the asset was created."
+            }
+          },
+          "required": [
+            "id",
+            "fileName",
+            "uploadUrl",
+            "status",
+            "byteSize",
+            "mediaType",
+            "checksum",
+            "updatedAt",
+            "createdAt"
+          ]
+        },
+        "error": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "nullable": false
+            },
+            "error_code": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "required": [
+            "message",
+            "error_code"
+          ]
+        },
+        "speech_enhancement": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "d7748c6d-4be9-41e7-a6a8-d4138eaa8219",
+              "description": "Unique ID of the speech enhancement."
+            },
+            "strength": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "nullable": false,
+              "example": 90,
+              "description": "Percentage strength of speech enhancement."
+            },
+            "modelId": {
+              "type": "string",
+              "nullable": false,
+              "example": "v1",
+              "description": "Unique identifier of the model that performs speech enhancement."
+            },
+            "assetId": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "bcab9f0c-f740-41f1-990e-c21f2cae6af0",
+              "description": "Unique ID of the asset of the speech enhancement."
+            },
+            "requestedProcessingAt": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": false,
+              "description": "Datetime of when the speech enhancement was created."
+            },
+            "finishedProcessingAt": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true,
+              "description": "Datetime of when the speech enhancement was completed."
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "failed",
+                "succeeded",
+                "processing",
+                "queued"
+              ],
+              "nullable": false,
+              "example": "processing",
+              "description": "Indicates the processing status of the speech enhancement."
+            },
+            "output": {
+              "type": "object",
+              "nullable": true,
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "nullable": true,
+                  "example": "https://bucket.s3-accelerate.amazonaws.com/Assets/...",
+                  "description": "URL that provides access to download the speech enhancement as a file. Only available when the status is `succeeded`."
+                }
+              }
+            }
+          },
+          "required": [
+            "id",
+            "strength",
+            "modelId",
+            "assetId",
+            "requestedProcessingAt",
+            "finishedProcessingAt",
+            "status",
+            "output"
+          ]
+        }
+      }
+    }
+  }

--- a/static/audio_show_asset.json
+++ b/static/audio_show_asset.json
@@ -1,0 +1,906 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+      "title": "Audio Services: Enhance Speech API",
+      "version": "v2"
+    },
+    "paths": {
+      "/v2/assets": {
+        "post": {
+          "summary": "Create an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Create an asset. You will receive an `uploadUrl` in the response, which you can use to upload the asset.",
+          "operationId": "createAsset",
+          "parameters": [
+
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "201": {
+              "description": "Asset created",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/asset"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Request missing required parameter fileName",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "request_missing_required_parameter": {
+                      "value": {
+                        "error_code": null,
+                        "message": "#/paths/~1v2~1assets/post/requestBody/content/application~1json/schema missing required parameters: fileName"
+                      },
+                      "summary": "Request missing a required parameter"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          },
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "fileName": {
+                      "type": "string",
+                      "description": "Name of the uploaded file (including file extension)."
+                    },
+                    "byteSize": {
+                      "type": "integer",
+                      "description": "Number of bytes of the file. Must match the value of the `Content-Length` header when uploading directly to S3."
+                    },
+                    "mediaType": {
+                      "type": "string",
+                      "description": "Content type of the file. Must match the value of `Content-Type` header when uploading directly to S3.",
+                      "enum": [
+                        "audio/aac",
+                        "audio/flac",
+                        "audio/m4a",
+                        "audio/mp4",
+                        "audio/mpeg",
+                        "audio/mpeg4-generic",
+                        "audio/ogg",
+                        "audio/opus",
+                        "audio/vnd.dlna.adts",
+                        "audio/vorbis",
+                        "audio/wav",
+                        "audio/x-aac",
+                        "audio/x-aiff",
+                        "audio/x-flac",
+                        "audio/x-m4a",
+                        "audio/x-wav"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "fileName",
+                    "byteSize",
+                    "mediaType"
+                  ]
+                },
+                "examples": {
+                  "name": {
+                    "summary": "summary",
+                    "value": {
+                      "fileName": "audio-file.mp3",
+                      "byteSize": 31005,
+                      "mediaType": "audio/mpeg"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/assets/{id}": {
+        "get": {
+          "summary": "Show an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Retrieve information about a specific asset identified by its `id`. This endpoint allows you to view the details of an asset that was previously created using the `POST /v2/assets` endpoint.",
+          "operationId": "getAsset",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired asset.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "200": {
+              "description": "Asset found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/asset"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "delete": {
+          "summary": "Delete an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Delete the asset with the specified `id`.",
+          "operationId": "deleteAsset",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired asset.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "204": {
+              "description": "Asset deleted",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_deleted": {
+                      "summary": "Asset and any speech enhancements successfully deleted"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/speech-enhancements": {
+        "post": {
+          "summary": "Create a speech enhancement",
+          "tags": [
+            "Speech Enhancements"
+          ],
+          "description": "This endpoint allows you to run speech enhancement, at a specific `strength`, on an asset (identified by `input.uploadId`).",
+          "operationId": "createSpeechEnhancement",
+          "parameters": [
+
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "202": {
+              "description": "Speech enhancement accepted",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/speech_enhancement"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Speech enhancement not created",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "speech_enhancement_already_exists": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Speech enhancement already exists for specified asset, model and strength."
+                      },
+                      "summary": "Speech enhancement already exists"
+                    },
+                    "non_ready_asset": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Asset has not been uploaded yet"
+                      },
+                      "summary": "Asset has not had a file uploaded"
+                    },
+                    "non_enhanceable_asset": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Asset is not enhanceable"
+                      },
+                      "summary": "Asset has a file, but enhancing has failed unexpectedly",
+                      "description": "Further requests to create enhancements for the same asset will fail. If the client is sure the file is enhanceable, they can create a new asset and try again"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          },
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "strength": {
+                      "type": "number",
+                      "minimum": 1,
+                      "maximum": 100,
+                      "example": 90,
+                      "description": "Percentage strength of speech enhancement."
+                    },
+                    "input": {
+                      "type": "object",
+                      "properties": {
+                        "uploadId": {
+                          "type": "string",
+                          "example": "audio-services:asset:91c8c3bf-be89-4284-a4f3-cfda5352fc4c",
+                          "description": "ID of the asset with identifying prefix to create a speech enhancement for."
+                        }
+                      },
+                      "required": [
+                        "uploadId"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "strength",
+                    "input"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/speech-enhancements/{id}": {
+        "get": {
+          "summary": "Get a speech enhancement",
+          "tags": [
+            "Speech Enhancements"
+          ],
+          "description": "Retrieve information about a speech enhancement for an asset, identified by `id`. This endpoint allows you to view the details of a speech enhancement that was previously created using the `POST /v2/speech-enhancements` endpoint.",
+          "operationId": "getSpeechEnhancement",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired speech enhancement.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "200": {
+              "description": "Speech enhancement found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/speech_enhancement"
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Speech enhancement not found",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "speech_enhancement_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Speech enhancement not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "servers": [
+      {
+        "url": "https://firefly-api-enterprise-stage.adobe.io/audio_services"
+      }
+    ],
+    "components": {
+      "securitySchemes": {
+        "bearer_auth": {
+          "type": "http",
+          "scheme": "bearer"
+        },
+        "api_key": {
+          "type": "apiKey",
+          "in": "header",
+          "name": "X-Api-Key"
+        }
+      },
+      "schemas": {
+        "asset": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "bcab9f0c-f740-41f1-990e-c21f2cae6af0",
+              "description": "Unique ID of the asset."
+            },
+            "fileName": {
+              "type": "string",
+              "nullable": false,
+              "example": "audio-file.mp3",
+              "description": "Name of uploaded file (including file extension)."
+            },
+            "uploadUrl": {
+              "type": "string",
+              "nullable": true,
+              "example": "https://bucket.s3-accelerate.amazonaws.com/Assets/...",
+              "description": "Pre-signed S3 URL to upload file to. Expires after 5 minutes. See guide and S3 [`PutObject` docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html)"
+            },
+            "status": {
+              "type": "string",
+              "nullable": false,
+              "enum": [
+                "waiting_for_upload",
+                "ready_for_processing",
+                "invalid_upload"
+              ],
+              "example": "waiting_for_upload",
+              "description": "Indicates the upload status of the Asset. The original status is `waiting_for_upload` and, after successfully being uploaded to S3, is `ready_for_processing`. An asset is `upload_invalid` if the underlying file is deemed unacceptable."
+            },
+            "byteSize": {
+              "type": "integer",
+              "nullable": true,
+              "minimum": 0,
+              "example": 31005,
+              "description": "Number of bytes of the file."
+            },
+            "mediaType": {
+              "type": "string",
+              "nullable": true,
+              "example": "audio/mpeg",
+              "description": "Media type of the file."
+            },
+            "checksum": {
+              "type": "string",
+              "nullable": true,
+              "example": "6gH7SfirkyEWPA+QeOuJjQ==",
+              "description": "Base64 encoded MD5 checksum of the uploaded file."
+            },
+            "updatedAt": {
+              "type": "string",
+              "nullable": false,
+              "format": "date-time",
+              "description": "Datetime of when the asset was last updated."
+            },
+            "createdAt": {
+              "type": "string",
+              "nullable": false,
+              "format": "date-time",
+              "description": "Datetime of when the asset was created."
+            }
+          },
+          "required": [
+            "id",
+            "fileName",
+            "uploadUrl",
+            "status",
+            "byteSize",
+            "mediaType",
+            "checksum",
+            "updatedAt",
+            "createdAt"
+          ]
+        },
+        "error": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "nullable": false
+            },
+            "error_code": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "required": [
+            "message",
+            "error_code"
+          ]
+        },
+        "speech_enhancement": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "d7748c6d-4be9-41e7-a6a8-d4138eaa8219",
+              "description": "Unique ID of the speech enhancement."
+            },
+            "strength": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "nullable": false,
+              "example": 90,
+              "description": "Percentage strength of speech enhancement."
+            },
+            "modelId": {
+              "type": "string",
+              "nullable": false,
+              "example": "v1",
+              "description": "Unique identifier of the model that performs speech enhancement."
+            },
+            "assetId": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "bcab9f0c-f740-41f1-990e-c21f2cae6af0",
+              "description": "Unique ID of the asset of the speech enhancement."
+            },
+            "requestedProcessingAt": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": false,
+              "description": "Datetime of when the speech enhancement was created."
+            },
+            "finishedProcessingAt": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true,
+              "description": "Datetime of when the speech enhancement was completed."
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "failed",
+                "succeeded",
+                "processing",
+                "queued"
+              ],
+              "nullable": false,
+              "example": "processing",
+              "description": "Indicates the processing status of the speech enhancement."
+            },
+            "output": {
+              "type": "object",
+              "nullable": true,
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "nullable": true,
+                  "example": "https://bucket.s3-accelerate.amazonaws.com/Assets/...",
+                  "description": "URL that provides access to download the speech enhancement as a file. Only available when the status is `succeeded`."
+                }
+              }
+            }
+          },
+          "required": [
+            "id",
+            "strength",
+            "modelId",
+            "assetId",
+            "requestedProcessingAt",
+            "finishedProcessingAt",
+            "status",
+            "output"
+          ]
+        }
+      }
+    }
+  }

--- a/static/audio_v2_spec_all.json
+++ b/static/audio_v2_spec_all.json
@@ -1,0 +1,906 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+      "title": "Audio Services: Enhance Speech API",
+      "version": "v2"
+    },
+    "paths": {
+      "/v2/assets": {
+        "post": {
+          "summary": "Create an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Create an asset. You will receive an `uploadUrl` in the response, which you can use to upload the asset.",
+          "operationId": "createAsset",
+          "parameters": [
+
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "201": {
+              "description": "Asset created",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/asset"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Request missing required parameter fileName",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "request_missing_required_parameter": {
+                      "value": {
+                        "error_code": null,
+                        "message": "#/paths/~1v2~1assets/post/requestBody/content/application~1json/schema missing required parameters: fileName"
+                      },
+                      "summary": "Request missing a required parameter"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          },
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "fileName": {
+                      "type": "string",
+                      "description": "Name of the uploaded file (including file extension)."
+                    },
+                    "byteSize": {
+                      "type": "integer",
+                      "description": "Number of bytes of the file. Must match the value of the `Content-Length` header when uploading directly to S3."
+                    },
+                    "mediaType": {
+                      "type": "string",
+                      "description": "Content type of the file. Must match the value of `Content-Type` header when uploading directly to S3.",
+                      "enum": [
+                        "audio/aac",
+                        "audio/flac",
+                        "audio/m4a",
+                        "audio/mp4",
+                        "audio/mpeg",
+                        "audio/mpeg4-generic",
+                        "audio/ogg",
+                        "audio/opus",
+                        "audio/vnd.dlna.adts",
+                        "audio/vorbis",
+                        "audio/wav",
+                        "audio/x-aac",
+                        "audio/x-aiff",
+                        "audio/x-flac",
+                        "audio/x-m4a",
+                        "audio/x-wav"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "fileName",
+                    "byteSize",
+                    "mediaType"
+                  ]
+                },
+                "examples": {
+                  "name": {
+                    "summary": "summary",
+                    "value": {
+                      "fileName": "audio-file.mp3",
+                      "byteSize": 31005,
+                      "mediaType": "audio/mpeg"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/assets/{id}": {
+        "get": {
+          "summary": "Show an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Retrieve information about a specific asset identified by its `id`. This endpoint allows you to view the details of an asset that was previously created using the `POST /v2/assets` endpoint.",
+          "operationId": "getAsset",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired asset.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "200": {
+              "description": "Asset found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/asset"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "delete": {
+          "summary": "Delete an asset",
+          "tags": [
+            "Assets"
+          ],
+          "description": "Delete the asset with the specified `id`.",
+          "operationId": "deleteAsset",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired asset.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "204": {
+              "description": "Asset deleted",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_deleted": {
+                      "summary": "Asset and any speech enhancements successfully deleted"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/speech-enhancements": {
+        "post": {
+          "summary": "Create a speech enhancement",
+          "tags": [
+            "Speech Enhancements"
+          ],
+          "description": "This endpoint allows you to run speech enhancement, at a specific `strength`, on an asset (identified by `input.uploadId`).",
+          "operationId": "createSpeechEnhancement",
+          "parameters": [
+
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "202": {
+              "description": "Speech enhancement accepted",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/speech_enhancement"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Speech enhancement not created",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "speech_enhancement_already_exists": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Speech enhancement already exists for specified asset, model and strength."
+                      },
+                      "summary": "Speech enhancement already exists"
+                    },
+                    "non_ready_asset": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Asset has not been uploaded yet"
+                      },
+                      "summary": "Asset has not had a file uploaded"
+                    },
+                    "non_enhanceable_asset": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Asset is not enhanceable"
+                      },
+                      "summary": "Asset has a file, but enhancing has failed unexpectedly",
+                      "description": "Further requests to create enhancements for the same asset will fail. If the client is sure the file is enhanceable, they can create a new asset and try again"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Asset does not exist",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "asset_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Asset not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          },
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "strength": {
+                      "type": "number",
+                      "minimum": 1,
+                      "maximum": 100,
+                      "example": 90,
+                      "description": "Percentage strength of speech enhancement."
+                    },
+                    "input": {
+                      "type": "object",
+                      "properties": {
+                        "uploadId": {
+                          "type": "string",
+                          "example": "audio-services:asset:91c8c3bf-be89-4284-a4f3-cfda5352fc4c",
+                          "description": "ID of the asset with identifying prefix to create a speech enhancement for."
+                        }
+                      },
+                      "required": [
+                        "uploadId"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "strength",
+                    "input"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2/speech-enhancements/{id}": {
+        "get": {
+          "summary": "Get a speech enhancement",
+          "tags": [
+            "Speech Enhancements"
+          ],
+          "description": "Retrieve information about a speech enhancement for an asset, identified by `id`. This endpoint allows you to view the details of a speech enhancement that was previously created using the `POST /v2/speech-enhancements` endpoint.",
+          "operationId": "getSpeechEnhancement",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "description": "ID of the desired speech enhancement.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "security": [
+            {
+              "bearer_auth": [
+
+              ],
+              "api_key": [
+
+              ]
+            }
+          ],
+          "responses": {
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_invalid": {
+                      "value": {
+                        "error_code": "401013",
+                        "message": "Oauth token is not valid"
+                      },
+                      "summary": "Access token is not valid"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Forbidden",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "access_token_lacks_proper_scope": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Missing required scope"
+                      },
+                      "summary": "Access token lacks the proper scope"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "too_many_requests": {
+                      "value": {
+                        "error_code": "429050",
+                        "message": "Too many requests"
+                      },
+                      "summary": "Client has made too many requests"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            },
+            "200": {
+              "description": "Speech enhancement found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/speech_enhancement"
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Speech enhancement not found",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "speech_enhancement_not_found": {
+                      "value": {
+                        "error_code": null,
+                        "message": "Not found"
+                      },
+                      "summary": "Speech enhancement not found"
+                    }
+                  },
+                  "schema": {
+                    "$ref": "#/components/schemas/error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "servers": [
+      {
+        "url": "https://firefly-api-enterprise-stage.adobe.io/audio_services"
+      }
+    ],
+    "components": {
+      "securitySchemes": {
+        "bearer_auth": {
+          "type": "http",
+          "scheme": "bearer"
+        },
+        "api_key": {
+          "type": "apiKey",
+          "in": "header",
+          "name": "X-Api-Key"
+        }
+      },
+      "schemas": {
+        "asset": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "bcab9f0c-f740-41f1-990e-c21f2cae6af0",
+              "description": "Unique ID of the asset."
+            },
+            "fileName": {
+              "type": "string",
+              "nullable": false,
+              "example": "audio-file.mp3",
+              "description": "Name of uploaded file (including file extension)."
+            },
+            "uploadUrl": {
+              "type": "string",
+              "nullable": true,
+              "example": "https://bucket.s3-accelerate.amazonaws.com/Assets/...",
+              "description": "Pre-signed S3 URL to upload file to. Expires after 5 minutes. See guide and S3 [`PutObject` docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html)"
+            },
+            "status": {
+              "type": "string",
+              "nullable": false,
+              "enum": [
+                "waiting_for_upload",
+                "ready_for_processing",
+                "invalid_upload"
+              ],
+              "example": "waiting_for_upload",
+              "description": "Indicates the upload status of the Asset. The original status is `waiting_for_upload` and, after successfully being uploaded to S3, is `ready_for_processing`. An asset is `upload_invalid` if the underlying file is deemed unacceptable."
+            },
+            "byteSize": {
+              "type": "integer",
+              "nullable": true,
+              "minimum": 0,
+              "example": 31005,
+              "description": "Number of bytes of the file."
+            },
+            "mediaType": {
+              "type": "string",
+              "nullable": true,
+              "example": "audio/mpeg",
+              "description": "Media type of the file."
+            },
+            "checksum": {
+              "type": "string",
+              "nullable": true,
+              "example": "6gH7SfirkyEWPA+QeOuJjQ==",
+              "description": "Base64 encoded MD5 checksum of the uploaded file."
+            },
+            "updatedAt": {
+              "type": "string",
+              "nullable": false,
+              "format": "date-time",
+              "description": "Datetime of when the asset was last updated."
+            },
+            "createdAt": {
+              "type": "string",
+              "nullable": false,
+              "format": "date-time",
+              "description": "Datetime of when the asset was created."
+            }
+          },
+          "required": [
+            "id",
+            "fileName",
+            "uploadUrl",
+            "status",
+            "byteSize",
+            "mediaType",
+            "checksum",
+            "updatedAt",
+            "createdAt"
+          ]
+        },
+        "error": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "nullable": false
+            },
+            "error_code": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "required": [
+            "message",
+            "error_code"
+          ]
+        },
+        "speech_enhancement": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "d7748c6d-4be9-41e7-a6a8-d4138eaa8219",
+              "description": "Unique ID of the speech enhancement."
+            },
+            "strength": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "nullable": false,
+              "example": 90,
+              "description": "Percentage strength of speech enhancement."
+            },
+            "modelId": {
+              "type": "string",
+              "nullable": false,
+              "example": "v1",
+              "description": "Unique identifier of the model that performs speech enhancement."
+            },
+            "assetId": {
+              "type": "string",
+              "nullable": false,
+              "format": "uuid",
+              "example": "bcab9f0c-f740-41f1-990e-c21f2cae6af0",
+              "description": "Unique ID of the asset of the speech enhancement."
+            },
+            "requestedProcessingAt": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": false,
+              "description": "Datetime of when the speech enhancement was created."
+            },
+            "finishedProcessingAt": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true,
+              "description": "Datetime of when the speech enhancement was completed."
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "failed",
+                "succeeded",
+                "processing",
+                "queued"
+              ],
+              "nullable": false,
+              "example": "processing",
+              "description": "Indicates the processing status of the speech enhancement."
+            },
+            "output": {
+              "type": "object",
+              "nullable": true,
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "nullable": true,
+                  "example": "https://bucket.s3-accelerate.amazonaws.com/Assets/...",
+                  "description": "URL that provides access to download the speech enhancement as a file. Only available when the status is `succeeded`."
+                }
+              }
+            }
+          },
+          "required": [
+            "id",
+            "strength",
+            "modelId",
+            "assetId",
+            "requestedProcessingAt",
+            "finishedProcessingAt",
+            "status",
+            "output"
+          ]
+        }
+      }
+    }
+  }


### PR DESCRIPTION
****DO NOT MERGE TO MAIN!!! - WORK IN PROGRESS****

## Description

Adds new Adobe Pro Audio & Video APIs tab, side nav and pages/placeholders for the Adobe Pro Audio & Video APIs. 

### Steps to run locally
- `yarn install`
- `node --max-old-space-size=8192 node_modules/gatsby/dist/bin/gatsby.js develop`
- Open browser to [http://localhost:8000/guides/](http://localhost:8000/guides/) for main FF Services site and  [http://localhost:8000/audio_video/](http://localhost:8000/audio_video/) to go directly to the new Pro Audio Video tab.
- Test for broken links with `yarn test:links`

** See the [AIO Theme](https://github.com/adobe/aio-theme/tree/main) this repo is based on for more components and usage details.


**IMPORTANT NOTES**
- Currently only the Audio Services APIs (Enhance Speech) will be going to GA at this time, so we need to determine if/how we want the nav and content to reflect exactly, before pushing to prod (ie: whether to include anything about "Video" yet or not). **Note:**  The [Dev Console service card will say both](https://jira.corp.adobe.com/browse/IOC-7668), so we should probably keep at least the top tab name to match and avoid too much confusion. This first pass includes video too everywhere, with a note that it's in private beta and coming soon. Here's a screenshot of the current nav for reference and the placeholder for Video Services:
  
    <img width="1425" alt="av-apis" src="https://github.com/AdobeDocs/ff-services-docs/assets/359935/65da7bbc-5ad8-430f-8d14-ffe0254dc370">

    <img width="1360" alt="av-apis-soon" src="https://github.com/AdobeDocs/ff-services-docs/assets/359935/72b59e50-46c1-4845-b410-9e72b67e7cd9">


(Note - the OVERVIEW, AUDIO SERVICES and VIDEO SERVICES titles on left nav are just categorizing, not clickable. But again, this nav is all up for debate depending on what we want to call out or not with the Video Services).

- I picked the banner color on the overview page based on the dark bluish color I saw in this screenshot, but it can be changed if there's some other brand color that makes more sense - or back to orange - though we've been using that for more core Firefly, so that's why I chose something else.

    <img width="1325" alt="Screen Shot 2024-06-24 at 9 49 55 PM" src="https://github.com/AdobeDocs/ff-services-docs/assets/359935/d13c1b0c-3aa8-4a4d-b802-18a609d225e0">

- I took a best guess for wording on titles and things on when to use "Audio Services" or "Adobe Pro Audio APIs" but needs review.
- The API Reference section files are all stubbed out with corresponding `<RedoclyBlock>` components and pointing to stubbed out new JSON files, but they need to actually be split out from [the overall v2 spec](https://github.com/AdobeDocs/ff-services-docs/blob/enhance-speech-api-docs/static/audio_v2_spec_all.json) and moved into their respective segments cc: @nimithajalal 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.- [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] 