### PR TITLE
x-model-version supports wider range of values following Image Model …

### DIFF
--- a/src/pages/firefly-api/guides/concepts/custom-models/index.md
+++ b/src/pages/firefly-api/guides/concepts/custom-models/index.md
@@ -34,9 +34,7 @@ Provide the asset ID in your API requests so that the generated images include t
 
 ## Performing CM image generation
 
-Perform CM inference by using the `/v3/images/generate-async` endpoint and including the header `x-model-version`. This specifies the model version used for generating the image.
-
-Currently, the only supported value is `image3_custom`.
+Perform CM inference by using the `/v3/images/generate-async` endpoint and including the header `x-model-version`. This specifies the model version used for generating the image, such as `image3_custom`.
 
 ### Request examples
 


### PR DESCRIPTION
…4 release

Update documentation to mention "image3_custom" as a value for the x-model-version HTTP header, without stating this is the only permitted value.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Doc bug fix (non-breaking change which fixes an issue, like a typo)
- [ ] Doc update (change which updates existing documentation)
- [ ] New content (change which adds net new pages or content)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->

## Related Issue/Ticket

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):
