### PR TITLE
get mainfest status examples hotfix

### DIFF
--- a/static/PITS/get_manifest_status.schema.json
+++ b/static/PITS/get_manifest_status.schema.json
@@ -7,7 +7,7 @@
   "properties": {
     "jobId": {
       "type": "string",
-      "description": "The job's id requested",
+      "description": "The ID of the job being requested.",
       "example": "f54e0fcb-260b-47c3-b520-de0d17dc2b67"
     },
     "outputs": {
@@ -34,13 +34,13 @@
           "created": {
             "type": "string",
             "format": "YYYY-DD-MMThh:mm:ss.mmmmmZ",
-            "description": "Created timestamp of the job.",
+            "description": "Timestamp for when the job was created.",
             "example": "2018-01-04T12:57:15.12345Z"
           },
           "modified": {
             "type": "string",
             "format": "YYYY-DD-MMThh:mm:ss.mmmmmZ",
-            "description": "Modified timestamp of the job.",
+            "description": "Timestamp for when the job was last modified.",
             "example": "2018-01-04T12:58:36.12345Z"
           },
           "document": {
@@ -48,37 +48,50 @@
             "properties": {
               "name": {
                 "type": "string",
-                "description": "Name of the input file",
+                "description": "The name of the input file.",
                 "example": "wine.psd"
               },
               "height": {
                 "type": "number",
-                "description": "In pixels",
+                "description": "Height, in pixels.",
                 "example" : 2100
               },
               "width": {
                 "type": "number",
-                "description": "In pixels",
+                "description": "Width, in pixels.",
                 "example" : 1500
               },
               "photoshopBuild": {
                 "type": "string",
-                "description": "The name of the application that created the PSD",
+                "description": "The name of the application that created the PSD.",
                 "example": "Adobe Photoshop CC 2019 (20180815.cyan.124 2018/08/15: 1186932)  (Macintosh)"
               },
               "imageMode": {
                 "type": "string",
                 "description": "The document's image mode.",
+                "enum": [
+                  "bitmap",
+                  "greyscale",
+                  "indexed",
+                  "rgb",
+                  "cmyk",
+                  "hsl",
+                  "hsb",
+                  "multichannel",
+                  "duotone",
+                  "lab",
+                  "xyz"
+                ],
                 "example" : "rgb"
               },
               "bitDepth": {
                 "type": "number",
-                "description": "The document's bit/channel depth. Allowed values `bitmap`, `greyscale`, `indexed`, `rgb`, `cmyk`, `hsl`, `hsb`, `multichannel`, `duotone`, `lab`, `xyz`",
-                "example" : "bitmap"
+                "description": "The document's bit/channel depth.",
+                "example" : 8
               },
               "iccProfileName": {
                 "type": "string",
-                "description": "icc profile",
+                "description": "The ICC profile name.",
                 "example" : "sRGB IEC61966-2.1"
               }
             }

--- a/static/PITS/get_status.schema.json
+++ b/static/PITS/get_status.schema.json
@@ -7,7 +7,7 @@
   "properties": {
     "jobId": {
       "type": "string",
-      "description": "The job's id requested",
+      "description": "The ID of the job being requested.",
       "example": "f54e0fcb-260b-47c3-b520-de0d17dc2b67"
     },
     "outputs": {
@@ -17,12 +17,11 @@
         "properties": {
           "input": {
             "type": "string",
-            "description": "The original input href.",
-            "example": "presigned_GET_URL"
+            "description": "The original input href."
           },
           "status": {
             "type": "string",
-            "description": "The job status",
+            "description": "The job status.",
             "enum": [
               "pending",
               "starting",
@@ -35,12 +34,12 @@
           "created": {
             "type": "string",
             "format": "YYYY-DD-MMThh:mm:ss.mmmmmZ",
-            "description": "Created timestamp of the job."
+            "description": "Timestamp for when the job was created."
           },
           "modified": {
             "type": "string",
             "format": "YYYY-DD-MMThh:mm:ss.mmmmmZ",
-            "description": "Modified timestamp of the job."
+            "description": "Timestamp for when the job was last modified."
           },
           "_links": {
             "type": "object",
@@ -79,7 +78,7 @@
           "properties": {
             "href": {
               "type": "string",
-              "description": "Link that client can use to track status.",
+              "description": "A link that can be used to track status.",
               "example": "https://image.adobe.io/pie/psdService/status/f54e0fcb-260b-47c3-b520-de0d17dc2b67"
             }
           }


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Doc bug fix (non-breaking change which fixes an issue, like a typo)
- [ ] Doc update (change which updates existing documentation)
- [ ] New content (change which adds net new pages or content)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

In the API spec for GET Status - Manifest, the description for `bitDepth` listed values that belong in `imageMode` instead.

## Related Issue/Ticket

https://creativecloud.slack.com/archives/CCAEDS6J2/p1750158020999389


## Screenshots (if appropriate):
