### PR TITLE
Hotfix/restore v2 markdown file

### DIFF
--- a/.cursor/rules/docs-lint.mdc
+++ b/.cursor/rules/docs-lint.mdc
@@ -14,8 +14,8 @@ This document outlines the linting rules and best practices for maintaining high
 ### Running the Linter
 
 ```bash
-yarn lint
-```
+   yarn lint
+   ```
 
 The linter checks:
 - Markdown files (markdownlint)

--- a/src/pages/lightroom/general-workflow/index.md
+++ b/src/pages/lightroom/general-workflow/index.md
@@ -28,7 +28,7 @@ The Lightroom API works with any public or signed url. We have documented a few 
 * [Node.js](https://github.com/AdobeDocs/cis-photoshop-api-docs/tree/main/sample-code/storage-app/aws-s3/presignedURLs.js) <br />Please note that creating pre-signed urls for AWS S3 requires signature version S3V4, as demonstrated in the sample code.
 * [Python](https://github.com/AdobeDocs/cis-photoshop-api-docs/tree/main/sample-code/storage-app/azure/presignedURLs.py)
 
-We also have a python [application](https://github.com/AdobeDocs/cis-photoshop-api-docs/tree/main/sample-code/storage-app/aws-s3/example.py) that provides a working example of how to call our api using assets stored in AWS S3.
+We also have a python [application](https://github.com/AdobeDocs/cis-photoshop-api-docs/tree/main/sample-code/storage-app/aws-s3/example.py) that provides a working example of how to call our api using assets stored in AWS S3.  
 
 **Google Drive:** Signed GET/PUT URL. For more information on how to setup your Google drive account for access to creating a signed URL [here](https://www.labnol.org/google-api-service-account-220404). Here are some code samples for getting signed urls.
 
@@ -46,30 +46,30 @@ We also have a python [application](https://github.com/AdobeDocs/cis-photoshop-a
 Run the curl command below to see if your input file path is working:
 
 ```bash
-curl -X GET <Your file path> --output <some-file.jpg>
-```
+  curl -X GET <Your file path> --output <some-file.jpg>
+  ```
 
 If you are using a presigned url, put your file path within "":
 
 ```bash
-curl -X GET "<Your file path>" --output <some-file.jpg>
-```
+  curl -X GET "<Your file path>" --output <some-file.jpg>
+  ```
 
 Run the curl command below to see if your output file path is working:
 
 ```bash
-curl -X PUT <Your file path> -d <some-file.txt>
-```
+  curl -X PUT <Your file path> -d <some-file.txt>
+  ```
 
 If you are using a presigned url, put your file path within "":
 
 ```bash
-curl -X PUT "<Your file path>" -d <some-file.txt>
-```
+  curl -X PUT "<Your file path>" -d <some-file.txt>
+  ``` 
 
 ## Current Limitations
 
-There are a few limitations to the APIs you should be aware of ahead of time.
+There are a few limitations to the APIs you should be aware of ahead of time. 
 
 * Multi-part uploads and downloads are not yet supported.
 * All the endpoints only support a single file input.

--- a/src/pages/photoshop/api/photoshop_removeBackgroundV2.md
+++ b/src/pages/photoshop/api/photoshop_removeBackgroundV2.md
@@ -1,0 +1,7 @@
+---
+title: Photoshop Remove Background API V2
+description: Remove the background from an image and generate a mask from an image.
+layout: none
+---
+
+<RedoclyAPIBlock src="/firefly-services/docs/photoshop_remove_backgroundV2.json" width="600px" disableSidebar hideTryItPanel scrollYOffset={64} generateCodeSamples="languages: [{lang: 'curl'}]" /> 

--- a/src/pages/photoshop/code-sample/index.md
+++ b/src/pages/photoshop/code-sample/index.md
@@ -1056,7 +1056,7 @@ The `/remove-background` API accepts a single input image and removes the backgr
 
 ```shell
 curl -i -X POST \
-  https://image.adobe.io/beta/remove-background \
+  https://image.adobe.io/v2/remove-background \
   -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' \
   -H 'Content-Type: application/json' \
   -H 'X-API-KEY: <YOUR_API_KEY_HERE>' \
@@ -1128,6 +1128,10 @@ Once the job is complete your successful `/status` response will look similar to
     }
 }
 ```
+
+### Generate image mask
+
+The workflow is exactly the same as [creating Remove Background](../code-sample/index.md#remove-background) except you use the `/mask` endpoint.
 
 ## Customized Workflow
 

--- a/src/pages/photoshop/code-sample/index.md
+++ b/src/pages/photoshop/code-sample/index.md
@@ -687,7 +687,7 @@ Once your job completes successfully (no errors/failures reported), the status r
                 "width":252
               },
               "text": {
-                "content":"Reset your customers’ expectations.",
+                "content":"Reset your customers' expectations.",
                 "paragraphStyles":[
                   {   
                     "alignment":"left"
@@ -703,7 +703,7 @@ Once your job completes successfully (no errors/failures reported), the status r
               "id":412,
               "index":6,
               "locked":false,
-              "name":"Reset your customers’ expectations.",
+              "name":"Reset your customers' expectations.",
               "type":"textLayer",
               "visible":true
             },
@@ -1052,27 +1052,35 @@ First, be sure to follow the instructions in the [Getting Started](../../guides/
 
 ### Remove Background
 
-The `/cutout` api takes a single input image to generate your mask or remove background from. Using [Example.jpg](https://github.com/AdobeDocs/cis-photoshop-api-docs/blob/main/sample_files/Example.jpg), a typical curl call might look like this:
+The `/remove-background` API accepts a single input image and removes the background from it. Using [Example.jpg](https://github.com/AdobeDocs/cis-photoshop-api-docs/blob/main/sample_files/Example.jpg), a typical cURL call might look like this:
 
 ```shell
-curl -X POST \
-  https://image.adobe.io/sensei/cutout \
-  -H "Authorization: Bearer $token"  \
-  -H "x-api-key: $apiKey" \
-  -H "Content-Type: application/json" \
+curl -i -X POST \
+  https://image.adobe.io/beta/remove-background \
+  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' \
+  -H 'Content-Type: application/json' \
+  -H 'X-API-KEY: <YOUR_API_KEY_HERE>' \
+  -H 'x-api-key: string' \
+  -H 'x-gw-ims-org-id: string' \
   -d '{
-   "input":{
-      "storage":"<storage>",
-      "href":"<SIGNED_GET_URL>"
-   },
-   "output":{
-      "storage":"<storage>",
-      "href":"<SIGNED_POST_URL>",
-      "mask":{
-         "format":"soft"
+    "image": {
+      "source": {
+        "url": "string"
       }
-   }
-}'
+    },
+    "mode": "cutout",
+    "output": {
+      "mediaType": "image/jpeg"
+    },
+    "trim": false,
+    "backgroundColor": {
+      "red": 255,
+      "green": 255,
+      "blue": 255,
+      "alpha": 1
+    },
+    "colorDecontamination": 0
+  }'
 ```
 
 This initiates an asynchronous job and returns a response containing the href to poll for job status and the JSON manifest.
@@ -1087,7 +1095,7 @@ This initiates an asynchronous job and returns a response containing the href to
 }
 ```
 
-Using the job id returned from the previous call you can poll on the returned `/status` href to get the job status
+Using the job ID returned from the previous call you can poll on the returned `/status` href to get the job status
 
 ```shell
 curl -X GET \
@@ -1120,10 +1128,6 @@ Once the job is complete your successful `/status` response will look similar to
     }
 }
 ```
-
-### Generate image mask
-
-The workflow is exactly the same as [creating Remove Background](../code-sample/index.md#remove-background) except you use the `/mask` endpoint instead of `/cutout`.  
 
 ## Customized Workflow
 


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Doc bug fix (non-breaking change which fixes an issue, like a typo)
- [ ] Doc update (change which updates existing documentation)
- [ ] New content (change which adds net new pages or content)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Hotfix to recapture changes that were lost in the revert of PR 200.
Critical V2 API changes for Photoshop have now been restored in this hotfix branch, including:

- The V2 markdown file
- The V2 JSON spec (already present)
- The navigation in gatsby-config.js (already correct)
- The code sample updates in src/pages/photoshop/code-sample/index.md

## Related Issue/Ticket

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):
