### PR TITLE
Update deploy.yml Exclude Folder defaults

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ on:
       excludeSubfolder:
         description: "Exclude a subfolder from deletion"
         required: false
-        default: "s3dapi, photoshop, indesign-apis, lightroom"
+        default: "photoshop, audio-video-api"
       index-mode:
         description: 'Type of indexing. "index" to push to Algolia, "console" for dry run.'
         required: true


### PR DESCRIPTION
Updated deploy.yml Exclude Folder defaults to include /audio-video-api and not include /indesign-apis.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Doc bug fix (non-breaking change which fixes an issue, like a typo)
- [ ] Doc update (change which updates existing documentation)
- [ ] New content (change which adds net new pages or content)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->

## Related Issue/Ticket

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):
