### PR TITLE
removed indesign-apis from the exclude folder to nullify the spoke repo

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -29,7 +29,7 @@
         clean_cache: 'true'
         path_prefix: ${{ steps.get_path_prefix.outputs.path_prefix }}
         branch_short_ref: ${{ steps.get_branch.outputs.branch }}
-        exclude_subfolder: 'photoshop, audio-video-api, s3dapi, indesign-apis'
+        exclude_subfolder: 'photoshop, audio-video-api, s3dapi'
     echo-state:
       needs: [set-state]
       runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ on:
       excludeSubfolder:
         description: "Exclude a subfolder from deletion"
         required: false
-        default: "photoshop, audio-video-api, s3dapi, indesign-apis"
+        default: "photoshop, audio-video-api, s3dapi"
       index-mode:
         description: 'Type of indexing. "index" to push to Algolia, "console" for dry run.'
         required: true


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Doc bug fix (non-breaking change which fixes an issue, like a typo)
- [ ] Doc update (change which updates existing documentation)
- [ ] New content (change which adds net new pages or content)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

InDesign API references are not loading in the live site. The unused spoke repo is not being excluded from the build and is causing issues.

## Related Issue/Ticket

https://adobeprovideo.slack.com/archives/C01GU3V8XE0/p1756922319696579


## Screenshots (if appropriate):
