### PR TITLE
feat/FFENT-9081: Add Workflow Builder API to global nav and services discovery

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -29,6 +29,11 @@ module.exports = {
         path: "https://developer.adobe.com/firefly-services/docs/firefly-api/?aio_internal",
       },
       {
+        title: "Workflow Builder API",
+        description: "Docs and references for Workflow Builder API",
+        path: "https://developer.adobe.com/firefly-services/docs/workflow-builder-api/?aio_internal",
+      },
+      {
         title: "Photoshop API",
         description: "Docs and references for Photoshop API",
         path: "https://developer.adobe.com/firefly-services/docs/photoshop/?aio_internal",

--- a/src/pages/guides/index.md
+++ b/src/pages/guides/index.md
@@ -113,6 +113,12 @@ Integrate generative AI into your creative workflows.
 
 <DiscoverBlock slots="link, text"/>
 
+[Workflow Builder API](https://developer.adobe.com/firefly-services/docs/workflow-builder-api/?aio_internal)
+
+Run published workflows over many assets at scale with batch execution, progress tracking, and per-asset results.
+
+<DiscoverBlock slots="link, text"/>
+
 [Lightroom API](https://developer.adobe.com/firefly-services/docs/lightroom/?aio_internal)
 
 Unlock the potential of Lightroom in the cloud.


### PR DESCRIPTION
## Summary

This PR adds **Workflow Builder API** to the Firefly Services docs site in two places: the global navigation and the guides landing page services discovery block.

TO BE DEPLOYED AFTER https://github.com/AdobeDocs/ffs-workflow-builder-api/pull/1, surfacing the Workflow Builder API on the hub.

## Changes

### 1. Global navigation (`gatsby-config.js`)
- Added a new nav item for **Workflow Builder API** in the theme config.
- **Title:** Workflow Builder API  
- **Description:** Docs and references for Workflow Builder API  
- **Path:** `https://developer.adobe.com/firefly-services/docs/workflow-builder-api/?aio_internal`

### 2. Guides landing page (`src/pages/guides/index.md`)
- Added a **DiscoverBlock** entry for Workflow Builder API in the services discovery section.
- **Link text:** Workflow Builder API (same URL as above).
- **Blurb:** *Run published workflows over many assets at scale with batch execution, progress tracking, and per-asset results.*
- Placement: between the existing Firefly API block and the Lightroom API block.

## Files modified
- `gatsby-config.js` — +5 lines (new nav item).
- `src/pages/guides/index.md` — +6 lines (new discovery block).

## Testing
- [ ] Global nav shows "Workflow Builder API" and links to the correct path.
- [ ] Guides index page shows the new Workflow Builder API discovery card with correct copy and link.

## Jira
FFENT-9081 — Workflow Builder GA

Made with [Cursor](https://cursor.com)