### PR TITLE
docs- Refine Gatsby sidebar for tutorials and Firefly API guides

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -125,18 +125,6 @@ module.exports = {
             path: "/firefly-api/guides/concepts/dev-console/",
           },
           {
-            title: "Authentication",
-            path: "/firefly-api/guides/concepts/authentication/",
-          },
-          {
-            title: "Image Upload",
-            path: "/firefly-api/guides/concepts/image-upload/",
-          },
-          {
-            title: "Masking",
-            path: "/firefly-api/guides/concepts/masking/",
-          },
-          {
             title: "Placement",
             path: "/firefly-api/guides/concepts/placement/",
           },
@@ -209,8 +197,8 @@ module.exports = {
             path: "/firefly-api/guides/api/generate-similar/V3_Async/",
           },
           {
-            title: "Generate Object Composite",
-            path: "/firefly-api/guides/api/generate-object-composite/V3_Async/",
+            title: "Test API",
+            path: "/firefly-api/guides/api/test_api",
           },
           {
             title: "Expand Image",

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -90,14 +90,14 @@ module.exports = {
             path: "/guides/tutorials/automate-workflow.md",
           },
           {
-            title: "Getting Started with the SDK",
+            title: "Using the Firefly Services SDK",
             path: "/guides/tutorials/using-the-sdk.md",
-          },  
+          },
+          {
+            title: "Creating Product Images at Scale with Firefly Services",
+            path: "/guides/tutorials/create-product-images-with-ff.md",
+          },
         ],
-      },
-      {
-        title: "Support",
-        path: "/guides/support/",
       },
       /*
       {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -189,18 +189,6 @@ module.exports = {
             path: "/firefly-api/guides/api/list_custom_models",
           },
           {
-            title: "Generate Images",
-            path: "/firefly-api/guides/api/image_generation/V3_Async/",
-          },
-          {
-            title: "Generate Similar Images",
-            path: "/firefly-api/guides/api/generate-similar/V3_Async/",
-          },
-          {
-            title: "Test API",
-            path: "/firefly-api/guides/api/test_api",
-          },
-          {
             title: "Expand Image",
             path: "/firefly-api/guides/api/generative_expand/V3_Async/",
           },


### PR DESCRIPTION
# Summary

This PR streamlines the Gatsby site sidebar by updating the **Guides → Tutorials** section and trimming redundant or superseded entries under **Firefly API** (concepts and API operation links). The goal is a shorter, clearer nav that matches current documentation priorities: emphasize the SDK and the product-images tutorial, drop the standalone Support bucket from this tree, and remove concept/API links that are duplicated elsewhere or no longer needed in the sidebar.

Net change is confined to `gatsby-config.js` (navigation only; no content file edits).

# Changes

## `gatsby-config.js`

* **Tutorials:** Renamed the SDK tutorial label from “Getting Started with the SDK” to “Using the Firefly Services SDK” (path unchanged: `using-the-sdk.md`).
* **Tutorials:** Added a sidebar entry for “Creating Product Images at Scale with Firefly Services” pointing at `create-product-images-with-ff.md`.
* **Tutorials:** Removed the **Support** subsection (`/guides/support/`) from the guides navigation block.
* **Firefly API — concepts:** Removed sidebar links for Authentication, Image Upload, and Masking (paths under `concepts/`).
* **Firefly API — API operations:** Removed sidebar links for Generate Images, Generate Similar Images, and Generate Object Composite (paths under `guides/api/`).

# Context

## Jira

No ticket
