### PR TITLE
fix axios vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@adobe/gatsby-theme-aio": "^4.15.5",
+    "axios": "0.30.0",
     "cis-lightroom-api": "github:adobedocs/cis-photoshop-api-docs#lr_docs",
     "firefly-api-docs": "github:adobedocs/firefly-api-docs",
     "gatsby": "4.22.0",
@@ -23,9 +24,13 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
+  "overrides": {
+    "axios": "0.30.0"
+  },
   "resolutions": {
-    "sharp": "0.33.0",
-    "gatsby-sharp": "1.12.0"
+    "axios": "0.30.0",
+    "gatsby-sharp": "1.12.0",
+    "sharp": "0.33.0"
   },
   "scripts": {
     "start": "gatsby build && gatsby serve",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6111,12 +6111,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.21.1":
-  version: 0.21.4
-  resolution: "axios@npm:0.21.4"
+"axios@npm:0.30.0":
+  version: 0.30.0
+  resolution: "axios@npm:0.30.0"
   dependencies:
-    follow-redirects: ^1.14.0
-  checksum: 44245f24ac971e7458f3120c92f9d66d1fc695e8b97019139de5b0cc65d9b8104647db01e5f46917728edfc0cfd88eb30fc4c55e6053eef4ace76768ce95ff3c
+    follow-redirects: ^1.15.4
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: 5179e93f4d8a4f8fc6fce3d46b4087aff60d1f2aeb36fad289e506dfd327c3436aafe1a91b371f47ffc2ef1b0a3f7ea278a24f6b1af88216d691b1e6c262b32f
   languageName: node
   linkType: hard
 
@@ -8552,6 +8554,7 @@ __metadata:
   resolution: "dev-site-documentation-template@workspace:."
   dependencies:
     "@adobe/gatsby-theme-aio": ^4.15.5
+    axios: 0.30.0
     cis-lightroom-api: "github:adobedocs/cis-photoshop-api-docs#lr_docs"
     firefly-api-docs: "github:adobedocs/firefly-api-docs"
     gatsby: 4.22.0
@@ -10362,7 +10365,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.0, follow-redirects@npm:^1.15.6":
+"follow-redirects@npm:^1.15.4, follow-redirects@npm:^1.15.6":
   version: 1.15.11
   resolution: "follow-redirects@npm:1.15.11"
   peerDependenciesMeta:
@@ -17517,6 +17520,13 @@ __metadata:
     forwarded: 0.2.0
     ipaddr.js: 1.9.1
   checksum: 29c6990ce9364648255454842f06f8c46fcd124d3e6d7c5066df44662de63cdc0bad032e9bf5a3d653ff72141cc7b6019873d685708ac8210c30458ad99f2b74
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: ed7fcc2ba0a33404958e34d95d18638249a68c430e30fcb6c478497d72739ba64ce9810a24f53a7d921d0c065e5b78e3822759800698167256b04659366ca4d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pin axios to 0.30.0 in dependencies, overrides, and resolutions to fix vulnerability.