### PR TITLE
docs- Rename Workflow Builder API to Creative Production API

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -30,7 +30,7 @@ module.exports = {
       },
       {
         title: "Creative Production API",
-        description: "Docs and references for Workflow Builder API",
+        description: "Docs and references for Firefly Creative Production API",
         path: "https://developer.adobe.com/firefly-services/docs/workflow-builder-api/?aio_internal",
       },
       {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -29,7 +29,7 @@ module.exports = {
         path: "https://developer.adobe.com/firefly-services/docs/firefly-api/?aio_internal",
       },
       {
-        title: "Workflow Builder API",
+        title: "Creative Production API",
         description: "Docs and references for Workflow Builder API",
         path: "https://developer.adobe.com/firefly-services/docs/workflow-builder-api/?aio_internal",
       },

--- a/src/pages/guides/index.md
+++ b/src/pages/guides/index.md
@@ -92,7 +92,7 @@ Integrate generative AI into your creative workflows.
 
 <DiscoverBlock slots="link, text"/>
 
-[Workflow Builder API](https://developer.adobe.com/firefly-services/docs/workflow-builder-api/?aio_internal)
+[Creative Production API](https://developer.adobe.com/firefly-services/docs/workflow-builder-api/?aio_internal)
 
 Run published workflows over many assets at scale with batch execution, progress tracking, and per-asset results.
 


### PR DESCRIPTION
# Summary
Updates site navigation and the guides landing page to use the **Creative Production API** name instead of **Workflow Builder API**, matching the service rename.

# Changes

## `gatsby-config.js`
* Sets the subnav entry title to Creative Production API.
* Updates the entry description to reference Firefly Creative Production API.

## `src/pages/guides/index.md`
* Renames the discover-block link label from Workflow Builder API to Creative Production API.

# Context

## Jira
No ticket
