### PR TITLE
docs- Add PR title conventions to contributing guide

### DIFF
--- a/CONTRIBUTING/CONTRIBUTING.md
+++ b/CONTRIBUTING/CONTRIBUTING.md
@@ -34,8 +34,21 @@ All submissions should come in the form of pull requests and need to be reviewed
 by project committers. Read [GitHub's pull request documentation](https://help.github.com/articles/about-pull-requests/)
 for more information on sending pull requests.
 
-Lastly, please follow the [pull request template](PULL_REQUEST_TEMPLATE.md) when
+PR title should include a commit type, which is used for tracking, for example `feat/FFENT-8796- Add validation for numVariations in OCAPI request`. Refer to this list of commit types we prefer to use:
+
+- **feat** — adds a new feature. These are markers for release notes and change log items.
+- **fix** — fixes a doc bug (like broken links or images).
+- **refactor** — rewrites/restructures code without changing behavior.
+- **style** — formatting/whitespace only; no meaning change. Only edits.
+- **docs** —  Content edits or additions. documentation only.
+- **build** — build tools, CI, dependencies, project version, etc.
+- **ops** — infrastructure, deployment, backup, recovery, etc.
+- **chore** — miscellaneous (e.g. `.gitignore`)
+
+Lastly, follow the [pull request template](/.github/PULL_REQUEST_TEMPLATE.md) when
 submitting a pull request!
+
+If you use an LLM, consider the Firefly docs [ruleset for commit messages](/.cursor/rules/commit-rules.mdc) and [automatic PR formatting](/.cursor/rules/pr-rules.mdc).
 
 ## From Contributor To Committer
 


### PR DESCRIPTION
# Summary
Documents how contributors should format PR titles (type and optional Jira key) and lists preferred commit types. Updates the PR template link to the repository path and points LLM-assisted authors to the project commit and PR rules.

# Changes

## `CONTRIBUTING/CONTRIBUTING.md`
* Adds guidance and a commit-type list for PR titles used for tracking and release notes.
* Changes the pull request template reference to `/.github/PULL_REQUEST_TEMPLATE.md`.
* Adds links to `.cursor/rules/commit-rules.mdc` and `.cursor/rules/pr-rules.mdc` for LLM workflows.

# Context

## Jira
No ticket


Made with [Cursor](https://cursor.com)