### PR TITLE
docs- Trim Support nav, SDK label, and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING/CONTRIBUTING.md
+++ b/CONTRIBUTING/CONTRIBUTING.md
@@ -4,12 +4,6 @@ The following are guidelines to follow when contributing to this project.
 
 Thanks for choosing to contribute to the docs!
 
-## Have Feedback?
-
-Start by filing an issue. You can use the button at the top of most document pages. The existing committers on this project work to reach
-consensus around project direction and issue solutions within issue threads
-(when appropriate).
-
 ![The button to Log and issue](/CONTRIBUTING/images/Log_an_issue.png)
 
 ## Contributor License Agreement
@@ -58,7 +52,3 @@ be invited to the project. The existing committers employ an internal nomination
 process that must reach lazy consensus (silence is approval) before invitations
 are issued. If you feel you are qualified and want to get more deeply involved,
 feel free to reach out to existing committers to have a conversation about that.
-
-## Security Issues
-
-Security issues shouldn't be reported on this issue tracker. Instead, [file an issue to our security experts](https://helpx.adobe.com/security/alertus.html).

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -91,9 +91,13 @@ module.exports = {
             path: "/guides/tutorials/create-product-images-with-ff.md",
           },
           {
-            title: "Getting Started with the SDK",
+            title: "Automate a Content Workflow",
+            path: "/guides/tutorials/automate-workflow.md",
+          },
+          {
+            title: "Getting Started with the APK",
             path: "/guides/tutorials/using-the-sdk.md",
-          },  
+          },
         ],
       },
       /*

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -83,20 +83,12 @@ module.exports = {
         path: "/guides/get-started.md",
       },
       {
-        title: "Support",
-        path: "/guides/support/",
-      },
-      {
         title: "Firefly tutorials",
         path: "/guides/tutorials",
         pages: [
           {
             title: "Creating Product Images at Scale",
             path: "/guides/tutorials/create-product-images-with-ff.md",
-          },
-          {
-            title: "Automate a Content Workflow",
-            path: "/guides/tutorials/automate-workflow.md",
           },
           {
             title: "Getting Started with the SDK",


### PR DESCRIPTION
# Summary
Updates the Getting started sidebar navigation and pares back the
contributing guide by removing sections that are no longer needed for this
branch.

# Changes

## `gatsby-config.js`
* Removes the Support entry from the Getting started sidebar.
* Renames the Firefly tutorials link text from Getting Started with the SDK
  to Getting Started with the APK (path unchanged).
* Removes stray trailing whitespace after the tutorials navigation items.

## `CONTRIBUTING/CONTRIBUTING.md`
* Removes the Have Feedback? section and related issue-filing guidance.
* Removes the Security Issues section and the external Adobe security
  reporting link.

# Context

## Jira
No ticket
