### PR TITLE
docs- Expand commit markers and revise PR conventions

### DIFF
--- a/.cursor/rules/commit-rules.mdc
+++ b/.cursor/rules/commit-rules.mdc
@@ -17,11 +17,32 @@ Leave one **blank line** after the subject before the body.
 ## Body (detailed description)
 
 - Wrap lines at about **72 characters** (including the bullet prefix and space).
-- Use **bullet lines** for the explanation. Each bullet must start with exactly one of:
-  - **📖** — use when the change **adds** something new: new files, new sections, new features, new headers, net-new lines, or other greenfield content.
-  - **✏️** — use when the change **modifies** existing work: edits to existing lines, updates to existing sections, refactors of existing code, or changes to current content.
+- Use **bullet lines** for the explanation. Each bullet must start with exactly one of these markers:
 
-Apply **📖** or **✏️** to every body bullet so it is clear what was introduced versus what was altered.
+### `📖` (adds)
+
+Use when the change **adds** something new: new files, new sections, new features, new headers, net-new lines, or other greenfield content.
+
+### `✏️` (modifies)
+
+Use when the change **modifies** existing work: edits to existing lines, updates to existing sections, refactors of existing code, or changes to current content.
+
+### `🆕` (TOC / feature registration)
+
+Use the single character **🆕** when the change **adds an entry** to a repository **table of contents** or **navigation config** file (for example `TOC.md`, `config.md`, or similar) that **registers a new feature, topic, or page**. This usually means a new item appears in the doc or site nav because of that edit.
+
+### `🗑️` (removes)
+
+Use the single character **🗑️** when **entire content is removed** from a page or file—not a light edit, but a full deletion. Typical cases:
+
+- A **section** removed (content under a heading marked with `#` through `######`)
+- An **image** removed (for example `![…](…)` or asset reference dropped entirely)
+- A **code block** removed (fenced or indented block gone completely)
+- A **component** or include removed (for example Experience League shortcodes, includes, or custom MDX-style blocks)
+
+Do **not** use **🗑️** for small wording tweaks inside a section; use **✏️** for those. Use **🗑️** when the heading (and everything under it), the image, the block, or the component no longer appears at all.
+
+Apply **📖**, **✏️**, **🆕**, or **🗑️** to every body bullet that matches the definitions above.
 
 ## Template
 
@@ -34,11 +55,19 @@ Fill in the placeholders (do not leave angle brackets in the final message):
 characters with bullets. >
 ```
 
-## Example
+## Examples
 
+```text
+Add AJO for GenStudio extensibility topic
+
+- 📖 Add journey-optimizer-for-genstudio.md and screenshot assets.
+- 🆕 Add Journey Optimizer for GenStudio to help/extensibility/TOC.md.
+- ✏️ Link the topic from use-templates.md and extensibility home.md.
 ```
-Add refresh token rotation to auth flow
 
-- 📖 Add refresh_tokens table and Alembic migration for schema v3.
-- ✏️ Update session middleware to rotate secrets and revoke old tokens.
+```text
+Trim obsolete troubleshooting page
+
+- 🗑️ Remove duplicate H2 “Known issues” and its bullets from activation/troubleshooting.md.
+- 🗑️ Drop outdated screenshot help/assets/legacy-flow.png from the repo.
 ```

--- a/.cursor/rules/pr-rules.mdc
+++ b/.cursor/rules/pr-rules.mdc
@@ -1,10 +1,10 @@
 ---
-description: PR title, body, and post-create Jira comment conventions for this repo
+description: PR title, body, and Jira-link conventions for this repo
 alwaysApply: true
 ---
 # Pull requests (PRs)
 
-When you draft, review, or **create** a pull request title or description (for example in GitHub/GitLab or when asked in Agent chat), follow these conventions.
+When you draft or review a pull request title or description (for example in GitHub/GitLab or when asked in Agent chat), follow these conventions.
 
 ## Deriving the Jira issue
 
@@ -40,13 +40,17 @@ Example:
 - **feat** — adds a new feature. When a new TOC item is added or the JIRA is connected to another `feat`- labeled Jira.
 - **fix** — fixes a bug
 - **refactor** — rewrites/restructures code without changing behavior
-- **perf** — improves performance (special refactor)
-- **style** — formatting/whitespace only; no meaning change. Only edits
+- **perf** — improves code performance (special refactor)
+- **style** — formatting/whitespace changes or refactoring the content architecture; no meaning change. Only edits
 - **test** — adds or corrects tests
-- **docs** —  New content added. documentation only
+- **docs** — new content added; documentation only
 - **build** — build tools, CI, dependencies, project version, etc.
 - **ops** — infrastructure, deployment, backup, recovery, etc.
 - **chore** — miscellaneous (e.g. `.gitignore`)
+
+## Link in Jira
+
+When a Jira ticket has been identified for the work, add a comment that includes the PR link once it has been created.
 
 ## PR body — required sections
 
@@ -97,25 +101,6 @@ Replace the key and URL with the actual ticket. If multiple tickets apply, list 
 ## Jira
 No ticket
 ```
-
-## Creating a PR — workflow
-
-When the user asks you to **create** a pull request, run this sequence:
-
-1. Inspect branch state (`git status`, diffs vs base, commit history) and draft the title and body using the conventions above.
-2. Push the branch to the remote with `-u` when it is not already published.
-3. Create the PR with `gh pr create` (HEREDOC body). Return the PR URL to the user.
-4. **Comment on linked Jira ticket(s)** — final step; do not skip when a ticket applies:
-   - **When** the branch name includes a Jira issue ID (or the PR `# Context` → `## Jira` section links one or more tickets): add a comment on **each** linked ticket with the PR URL.
-   - **When** `## Jira` is `No ticket`: skip this step.
-   - **Comment body** (one line; adjust only the PR URL):
-
-     ```text
-     Pull request: https://github.com/<org>/<repo>/pull/<number>
-     ```
-
-   - Prefer the **Jira MCP server** (`user-jira`) to post the comment when it is available and authenticated.
-   - If Jira MCP is unavailable or the comment fails, tell the user which ticket(s) still need the PR link and include the URL so they can add it manually.
 
 ## Example (full PR description)
 


### PR DESCRIPTION
# Summary
Expands the commit-message marker set and revises the PR conventions in the shared `.cursor/rules`, keeping the agent rules in sync with the latest documented workflow.

# Changes

## `.cursor/rules/commit-rules.mdc`
* Add 🆕 (TOC / navigation-config registration) and 🗑️ (full content removal) markers alongside the existing 📖 (adds) and ✏️ (modifies), each with its own definition.
* Replace the single example with two: a TOC-registration example and a content-removal example.

## `.cursor/rules/pr-rules.mdc`
* Scope the intro to draft/review, reword the commit-type definitions (`perf`, `style`, `docs`).
* Replace the detailed post-create `gh`/MCP workflow with a concise "Link in Jira" step.
* Update the frontmatter description to match.

# Context

## Jira
No ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)