### PR TITLE
feat- Add Claude Code commands and agents

### DIFF
--- a/.claude/agents/api-spec-reviewer.md
+++ b/.claude/agents/api-spec-reviewer.md
@@ -1,0 +1,13 @@
+---
+name: api-spec-reviewer
+description: Runs Redocly lint on OpenAPI JSON under static/, applies api-fix (lint and structure), then suggests api-eval for style and copy. Use proactively after editing static/**/*.json OpenAPI specs.
+tools: Bash, Read, Edit, Grep, Glob
+---
+
+You are an OpenAPI lint specialist for Firefly Services API documentation repos.
+
+Read @.cursor/agents/api-spec-reviewer.md and follow it exactly. In short: resolve
+the spec (no `petstore.json` default), run `npm run lint:openapi -- <path>`, fix
+only lint + structure findings via @.cursor/skills/api-fix/SKILL.md, re-run until
+clean, and suggest `/api-eval` or `/api-review` for any style/copy issues you
+noticed but did not fix. Never invent a placeholder spec; prefer minimal edits.

--- a/.claude/agents/doc-lint-fixer.md
+++ b/.claude/agents/doc-lint-fixer.md
@@ -1,0 +1,15 @@
+---
+name: doc-lint-fixer
+description: Runs npm run lint on Adobe Docs-style repos (adp-devsite-utils), fixes markdown/style/syntax issues from output, and lists dead-link findings for the user. Use proactively after editing src/pages/** or when CI lint fails.
+tools: Bash, Read, Edit, Grep, Glob
+---
+
+You are a documentation lint specialist for repos that use Adobe's devsite lint
+pipeline.
+
+Read @.cursor/agents/doc-lint-fixer.md and follow it exactly. In short: run
+`npm run lint` from the repo root, fix non-link issues (markdown syntax,
+structure, style, frontmatter) with minimal edits matching project conventions,
+re-run until non-link problems are resolved, and collect link/URL failures into a
+clearly labeled "Link errors (for you to fix)" list without inventing replacement
+URLs.

--- a/.claude/commands/api-eval.md
+++ b/.claude/commands/api-eval.md
@@ -1,0 +1,10 @@
+---
+description: Audit an OpenAPI JSON spec (Redocly lint, version, FFS style guide, copy rules). Read-only — no edits.
+argument-hint: "[path to spec under static/]"
+---
+
+Read @.cursor/skills/api-eval/SKILL.md and follow it to audit the OpenAPI spec.
+Resolve the spec path with @.cursor/skills/_shared/resolve-api-spec.md (no
+`petstore.json` default); use `$ARGUMENTS` as the spec path when provided.
+
+Read-only: report findings only, do not edit the spec.

--- a/.claude/commands/api-fix.md
+++ b/.claude/commands/api-fix.md
@@ -1,0 +1,12 @@
+---
+description: Fix Redocly lint errors and api-ref-structure issues on an OpenAPI JSON spec (edits the file).
+argument-hint: "[path to spec under static/]"
+---
+
+Read @.cursor/skills/api-fix/SKILL.md and follow it to fix Redocly lint errors
+and `api-ref-structure.mdc` inconsistencies. Resolve the spec path with
+@.cursor/skills/_shared/resolve-api-spec.md (no `petstore.json` default); use
+`$ARGUMENTS` as the spec path when provided.
+
+Scope: lint + structure only. Do not apply FFS style-guide or copy edits — those
+belong to `/api-eval` and `/api-review`.

--- a/.claude/commands/api-review.md
+++ b/.claude/commands/api-review.md
@@ -1,0 +1,12 @@
+---
+description: Catalog user-readable OpenAPI text in ref-numbered tables with issues and proposed content. Read-only.
+argument-hint: "[path to spec under static/]"
+---
+
+Read @.cursor/skills/api-review/SKILL.md and follow it to catalog the spec's
+user-readable descriptions in ref-numbered tables with possible issues and
+proposed content. Resolve the spec path with
+@.cursor/skills/_shared/resolve-api-spec.md (no `petstore.json` default); use
+`$ARGUMENTS` as the spec path when provided.
+
+Read-only unless the user explicitly asks to update specific refs.

--- a/.claude/commands/gc.md
+++ b/.claude/commands/gc.md
@@ -1,0 +1,11 @@
+---
+description: Stage all changes and commit using the repo commit-message rules (📖/✏️/🆕/🗑️).
+---
+
+Read @.cursor/skills/gc/SKILL.md and follow it exactly: stage all working-tree
+changes with `git add -A`, then commit with a message that follows
+@.cursor/rules/commit-rules.mdc (imperative subject ≤50 chars, blank line, body
+bullets prefixed with 📖 / ✏️ / 🆕 / 🗑️).
+
+Do not run if the user only wanted a message draft, or wanted to stage specific
+paths — confirm scope first.

--- a/.claude/commands/gcam.md
+++ b/.claude/commands/gcam.md
@@ -1,0 +1,8 @@
+---
+description: Stage all changes, draft a commit message for review, then commit or reject on the user's choice.
+---
+
+Read @.cursor/skills/gcam/SKILL.md and follow it exactly: stage all changes with
+`git add -A`, draft a commit message that follows @.cursor/rules/commit-rules.mdc,
+print it for review, and wait for the user to edit and choose (1) commit or
+(2) reject. This is the review-before-commit variant of `/gc`.


### PR DESCRIPTION
# Summary
Adds Claude Code slash commands and subagents under `.claude/`, mirroring the existing Cursor skills/agents so the same workflows are available to Claude Code. Each file is a thin wrapper that points at the canonical `.cursor/skills` and `.cursor/agents` sources, so there is no duplicated procedure text to drift. Repos that symlink into this one (e.g. via the shared `.cursor`/`.claude` pattern) get these for free.

# Changes

## `.claude/commands/gc.md`, `gcam.md`
* Stage-and-commit commands wrapping `.cursor/skills/gc` and `gcam`, honoring the repo commit-message rules.

## `.claude/commands/api-eval.md`, `api-fix.md`, `api-review.md`
* OpenAPI spec commands wrapping the matching `.cursor/skills`, with spec-path argument hints.

## `.claude/agents/api-spec-reviewer.md`, `doc-lint-fixer.md`
* Subagents wrapping the `.cursor/agents` specs for OpenAPI lint and docs lint.

# Context

## Jira
No ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)